### PR TITLE
feat: implement layers panel with CRUD, drag reorder, visibility, rename, and blend modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "texlab",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "dockview": "^5.2.0",
@@ -709,6 +712,73 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3483,6 +3553,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.7.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     ]
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "dockview": "^5.2.0",

--- a/specs/010-layers-panel/checklists/requirements.md
+++ b/specs/010-layers-panel/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Layers Panel
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Specification is ready for `/speckit.clarify` or `/speckit.plan`.
+- Blend mode dropdown is mentioned in the issue tasks but not present in the UI design component — the spec includes it per the issue requirements. Design may need updating.
+- Opacity editing (slider/input) is explicitly marked out of scope — only display.

--- a/specs/010-layers-panel/contracts/ipc.md
+++ b/specs/010-layers-panel/contracts/ipc.md
@@ -1,0 +1,100 @@
+# IPC Contracts: Layers Panel
+
+**Feature**: 010-layers-panel | **Date**: 2026-04-01
+
+All commands return `Result<EditorStateDto, AppError>` unless noted. All emit the `"state-changed"` Tauri event on success.
+
+## New Command
+
+### `duplicate_layer`
+
+Duplicates the specified layer, inserting the copy directly above the original.
+
+**Input**:
+```typescript
+invoke("duplicate_layer", { layerId: string })
+```
+
+| Param | Type | Description |
+|-------|------|-------------|
+| layerId | string | 32-char hex ID of the layer to duplicate |
+
+**Output**: `EditorStateDto` with the new duplicate in the layers array, set as `activeLayerId`.
+
+**Behavior**:
+1. Parse `layerId` to `LayerId`.
+2. Call `EditorService::duplicate_layer(source_id, new_id)`.
+3. Set `active_layer_id` to the new duplicate's ID.
+4. Emit `"state-changed"`.
+
+**Errors**:
+- Layer not found (invalid ID).
+
+**Undo**: Recorded as `OperationType::LayerAdd`. Undo removes the duplicate.
+
+---
+
+## Modified Commands
+
+### `add_layer` (behavior change)
+
+Previously appended new layer to the top of the stack. Now inserts above the active layer.
+
+**Input** (unchanged):
+```typescript
+invoke("add_layer", { name: string })
+```
+
+**Behavior change**:
+- If there is an active layer: inserts new layer at `active_layer_index + 1`.
+- If no active layer (no texture or empty stack): appends to top (unchanged).
+
+### `remove_layer` (guard added)
+
+**New guard**: Rejects removal when only 1 layer remains.
+
+**New error**: `"Cannot delete the last layer"` (AppError::Internal).
+
+---
+
+## Modified DTO
+
+### `LayerInfoDto` (field added)
+
+```typescript
+interface LayerInfoDto {
+  id: string;
+  name: string;
+  opacity: number;
+  blendMode: BlendMode;
+  visible: boolean;
+  locked: boolean;
+  thumbnail: number[];  // NEW: raw RGBA bytes, length = width * height * 4
+}
+```
+
+The `thumbnail` contains the layer's raw pixel data. Width and height are taken from `EditorStateDto.texture.width` and `EditorStateDto.texture.height` (all layers share texture dimensions).
+
+---
+
+## Existing Commands (unchanged)
+
+These commands already exist and require no modifications:
+
+| Command | Input | Notes |
+|---------|-------|-------|
+| `move_layer` | `{ fromIndex: number, toIndex: number }` | Index-based reorder |
+| `set_layer_visibility` | `{ layerId: string, visible: boolean }` | Toggle eye icon |
+| `set_layer_blend_mode` | `{ layerId: string, blendMode: string }` | Dropdown change |
+| `set_layer_name` | `{ layerId: string, name: string }` | Inline rename confirm |
+| `set_layer_opacity` | `{ layerId: string, opacity: number }` | Display only in this feature (no editor) |
+| `set_layer_locked` | `{ layerId: string, locked: boolean }` | Not in scope for panel UI |
+| `get_editor_state` | -- | Full state query |
+
+---
+
+## Events
+
+| Event | Direction | Payload | Notes |
+|-------|-----------|---------|-------|
+| `"state-changed"` | Rust -> Frontend | None | Emitted by all mutation commands. Frontend calls `refreshState()` to re-fetch `EditorStateDto`. |

--- a/specs/010-layers-panel/data-model.md
+++ b/specs/010-layers-panel/data-model.md
@@ -1,0 +1,130 @@
+# Data Model: Layers Panel
+
+**Feature**: 010-layers-panel | **Date**: 2026-04-01
+
+## Domain Entities (existing, extended)
+
+### Layer (`domain/layer.rs`)
+
+Existing entity. Addition: `duplicate()` method.
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| id | LayerId(u128) | Unique, immutable | UUID-based, generated in commands layer |
+| name | String | Non-empty | Validated at construction and rename |
+| buffer | PixelBuffer | width x height x 4 RGBA bytes | Transparent on creation |
+| opacity | f32 | Clamped [0.0, 1.0] | Default 1.0 |
+| blend_mode | BlendMode | Normal/Multiply/Screen/Overlay | Default Normal |
+| visible | bool | -- | Default true |
+| locked | bool | -- | Default false |
+
+**New method**:
+```
+duplicate(new_id: LayerId) -> Result<Layer, DomainError>
+```
+Creates a copy with the given ID, name suffixed with " (copy)", all properties cloned, buffer deep-copied.
+
+### LayerStack (`domain/layer_stack.rs`)
+
+Existing entity. Additions: `insert_layer()`, `index_of()`.
+
+**New methods**:
+```
+insert_layer(index: usize, layer: Layer) -> Result<(), DomainError>
+  - Validates index <= len (allows appending at end)
+  - Inserts layer at position in the internal Vec
+
+index_of(id: LayerId) -> Option<usize>
+  - Returns the position of the layer with the given ID
+```
+
+### BlendMode (`domain/blend.rs`)
+
+Existing enum, unchanged.
+
+```
+Normal | Multiply | Screen | Overlay
+```
+
+## Use Case Operations (existing, extended)
+
+### EditorService (`use_cases/editor_service.rs`)
+
+**New methods**:
+
+```
+add_layer_above(id: LayerId, name: &str, above_id: Option<LayerId>) -> Result<(), DomainError>
+  - If above_id is Some: finds index, inserts at index + 1
+  - If above_id is None: appends to top (same as current add_layer)
+  - Records undo entry (OperationType::LayerAdd)
+
+duplicate_layer(source_id: LayerId, new_id: LayerId) -> Result<(), DomainError>
+  - Finds source layer, gets its index
+  - Calls source.duplicate(new_id)
+  - Inserts duplicate at source_index + 1
+  - Records undo entry (OperationType::LayerAdd)
+```
+
+## DTOs (IPC boundary)
+
+### LayerInfoDto (`commands/dto.rs`)
+
+Extended with thumbnail field.
+
+| Field | Rust Type | TS Type | Notes |
+|-------|-----------|---------|-------|
+| id | String | string | 32-char hex of u128 |
+| name | String | string | Display name |
+| opacity | f32 | number | 0.0 to 1.0 |
+| blend_mode | String | BlendMode | "normal"/"multiply"/"screen"/"overlay" |
+| visible | bool | boolean | Visibility state |
+| locked | bool | boolean | Lock state |
+| **thumbnail** | **Vec\<u8\>** | **number[]** | **Raw RGBA bytes. Width/height from TextureMetadataDto.** |
+
+### EditorStateDto (`commands/dto.rs`)
+
+Unchanged. Already contains `layers: Vec<LayerInfoDto>`, `active_layer_id: Option<String>`.
+
+## State Flow
+
+```
+User action (click, drag, keystroke)
+  |
+  v
+React component handler
+  |
+  v
+api/commands.ts (invoke IPC)
+  |
+  v
+Rust commands/ (lock Mutex<AppState>, delegate to EditorService)
+  |
+  v
+EditorService (capture undo snapshot, call domain methods)
+  |
+  v
+Domain (Layer, LayerStack) -- pure logic
+  |
+  v
+EditorService (record undo entry, mark dirty)
+  |
+  v
+Rust commands/ (build EditorStateDto, emit "state-changed" event)
+  |
+  v
+Tauri IPC response -> frontend receives EditorStateDto
+  |
+  v
+editorStore.refreshState() -> Zustand update -> React re-render
+```
+
+## Validation Rules
+
+| Rule | Layer | Where Enforced |
+|------|-------|----------------|
+| Name non-empty | Layer::new, Layer::set_name | Domain |
+| Opacity [0.0, 1.0] | Layer::set_opacity | Domain (clamped) |
+| Blend mode valid | str_to_blend_mode | Commands/DTO |
+| Min 1 layer | remove_layer | Commands (guard before calling EditorService) |
+| Layer exists | get_layer/get_layer_mut | Domain (Option/Error) |
+| Index in bounds | insert_layer, move_layer | Domain |

--- a/specs/010-layers-panel/plan.md
+++ b/specs/010-layers-panel/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: Layers Panel
+
+**Branch**: `010-layers-panel` | **Date**: 2026-04-01 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/010-layers-panel/spec.md`
+
+## Summary
+
+Implement a fully interactive "Layers" panel for the TexLab pixel art editor. The panel displays all layers of the active texture with thumbnails, supports CRUD operations (add/delete/duplicate), drag-and-drop reordering, inline rename, visibility toggle, and blend mode selection. All operations synchronize with the Rust backend via Tauri IPC and support undo/redo. The backend already provides most layer commands; the main gaps are `duplicate_layer`, insert-at-position, and thumbnail data in the DTO.
+
+## Technical Context
+
+**Language/Version**: Rust >= 1.77 (backend), TypeScript ^5.7 (frontend)
+**Primary Dependencies**: tauri ^2.10, react ^19.2, zustand ^5.0, dockview ^5.2, lucide-react ^1.7, @dnd-kit/core + @dnd-kit/sortable (new)
+**Storage**: N/A (in-memory AppState, persisted via .texlab archives in future features)
+**Testing**: vitest + @testing-library/react (frontend), cargo test (backend)
+**Target Platform**: Windows/macOS/Linux desktop (Tauri v2)
+**Project Type**: Desktop application (Tauri v2 -- Rust + React)
+**Performance Goals**: Panel responsive with <=50 layers (SC-007), layer operations <500ms (SC-002), visibility toggle instant (SC-004)
+**Constraints**: Clean Architecture (domain purity), no serde on domain types, dual-access state (frontend + MCP)
+**Scale/Scope**: 1 panel component tree, ~5 new frontend files, ~4 modified backend files, 1 new dependency (@dnd-kit)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Clean Architecture | PASS | `duplicate_layer` follows existing pattern: domain -> use_cases -> commands. Thumbnail data extracted at DTO conversion level (commands layer). |
+| II. Domain Purity | PASS | New domain methods (`Layer::duplicate`, `LayerStack::insert_layer`, `LayerStack::index_of`) use zero external deps. No serde on domain types. |
+| III. Dual-Access State | PASS | All layer operations go through EditorService, reusable by MCP. "state-changed" event emitted on every mutation. |
+| IV. Test-First Domain | PASS | New domain methods (`duplicate`, `insert_layer`, `index_of`) and use case (`duplicate_layer`, `add_layer_above`) will have unit tests. |
+| V. Progressive Processing | N/A | Not related to texture conversion. |
+| VI. Simplicity | PASS | Thumbnails = raw RGBA in DTO (1KB/layer at 16x16, negligible). @dnd-kit justified by visual feedback requirement (US4-AS2). No virtualization needed for <=50 layers. |
+| VII. Component-Based UI | PASS | Self-contained panel with own store subscriptions, follows existing ColorPanel/CanvasViewport pattern. |
+
+**Pre-Phase 0 gate: PASSED**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-layers-panel/
+  plan.md              # This file
+  research.md          # Phase 0 output
+  data-model.md        # Phase 1 output
+  quickstart.md        # Phase 1 output
+  contracts/
+    ipc.md             # Tauri IPC contracts for layer operations
+  tasks.md             # Phase 2 output (NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src-tauri/src/
+  domain/
+    layer.rs             # MODIFY: add duplicate() method
+    layer_stack.rs       # MODIFY: add insert_layer(), index_of()
+  use_cases/
+    editor_service.rs    # MODIFY: add duplicate_layer(), add_layer_above()
+  commands/
+    dto.rs               # MODIFY: add thumbnail to LayerInfoDto
+    layer_commands.rs    # MODIFY: add duplicate_layer cmd, update add_layer to insert above active
+  lib.rs                 # MODIFY: register duplicate_layer in generate_handler!
+
+src/
+  api/
+    commands.ts          # MODIFY: add duplicateLayer(), update LayerInfoDto type
+  components/
+    layers/              # NEW: feature module
+      LayersPanel.tsx    # Main panel implementation
+      LayerRow.tsx       # Single layer row (thumbnail, name, visibility, opacity)
+      BlendModeSelect.tsx # Blend mode dropdown component
+    panels/
+      LayersPanel.tsx    # MODIFY: thin dockview wrapper -> delegates to layers/LayersPanel
+  package.json           # MODIFY: add @dnd-kit/core, @dnd-kit/sortable
+```
+
+**Structure Decision**: Frontend components live in `components/layers/` as a feature module, consistent with `components/canvas/` and `components/color/`. The existing `panels/LayersPanel.tsx` becomes a thin dockview wrapper (same pattern as `panels/CanvasViewportPanel.tsx`).
+
+## Complexity Tracking
+
+No violations. All decisions align with constitution principles.
+
+## Key Decisions
+
+| Decision | Rationale | See |
+|----------|-----------|-----|
+| @dnd-kit for drag-and-drop | Lightweight, accessible, purpose-built for sortable lists | [research.md](./research.md#1-drag-and-drop-library) |
+| Raw RGBA thumbnails in LayerInfoDto | Simplest for 16x16 textures (~1KB/layer), avoids separate fetch | [research.md](./research.md#2-layer-thumbnail-strategy) |
+| No list virtualization | SC-007 requires <=50 layers; no perf concern for a flat list | [research.md](./research.md#3-layer-list-rendering) |
+| Custom inline input for rename | Native contentEditable is unreliable; controlled input is simple | [research.md](./research.md#4-inline-rename-pattern) |

--- a/specs/010-layers-panel/quickstart.md
+++ b/specs/010-layers-panel/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: Layers Panel
+
+**Feature**: 010-layers-panel | **Branch**: `010-layers-panel`
+
+## Prerequisites
+
+- Rust >= 1.77, Node.js >= 20
+- Run `npm install` to get all dependencies (including @dnd-kit after tasks add it)
+- Run `cargo check` in `src-tauri/` to verify Rust compiles
+
+## Dev Workflow
+
+```bash
+# Start Tauri dev (Rust backend + Vite frontend)
+npm run tauri dev
+
+# Run Rust tests
+cd src-tauri && cargo test
+
+# Run frontend tests
+npm test
+
+# Type check
+npm run typecheck
+
+# Lint
+npm run check
+```
+
+## Key Files to Know
+
+### Backend (what to modify)
+
+| File | What | Why |
+|------|------|-----|
+| `src-tauri/src/domain/layer.rs` | Layer struct | Add `duplicate()` method |
+| `src-tauri/src/domain/layer_stack.rs` | Layer collection | Add `insert_layer()`, `index_of()` |
+| `src-tauri/src/use_cases/editor_service.rs` | Business logic | Add `duplicate_layer()`, `add_layer_above()` |
+| `src-tauri/src/commands/dto.rs` | IPC DTOs | Add `thumbnail` to `LayerInfoDto` |
+| `src-tauri/src/commands/layer_commands.rs` | Tauri commands | Add `duplicate_layer`, modify `add_layer`, guard `remove_layer` |
+| `src-tauri/src/lib.rs` | Command registration | Add `duplicate_layer` to `generate_handler!` |
+
+### Frontend (what to create/modify)
+
+| File | What | Why |
+|------|------|-----|
+| `src/api/commands.ts` | IPC wrappers | Add `duplicateLayer()`, update `LayerInfoDto` type |
+| `src/components/layers/LayersPanel.tsx` | NEW: main panel | Layer list, blend mode, actions |
+| `src/components/layers/LayerRow.tsx` | NEW: layer row | Thumbnail, name, visibility, opacity display |
+| `src/components/layers/BlendModeSelect.tsx` | NEW: dropdown | Blend mode selector |
+| `src/components/panels/LayersPanel.tsx` | Thin wrapper | Delegates to `layers/LayersPanel` |
+| `src/store/editorStore.ts` | State store | Already has layers/activeLayerId -- no changes needed |
+
+### Design Reference
+
+| Resource | Location |
+|----------|----------|
+| UI design | `ui-design` (.pen file, open with Pencil MCP tools) |
+| Component | `Panel-Layers` node in the .pen file |
+| Theme tokens | `src/styles/theme.ts` -- colors, fonts, fontSizes |
+
+## Architecture Reminders
+
+- **Domain purity**: No serde, tauri, or image imports in `domain/` or `use_cases/`.
+- **Thin commands**: Commands lock state, delegate to EditorService, build DTOs, emit events. No business logic.
+- **Frontend is a cache**: Zustand stores mirror Rust state. Frontend does NOT own layer data.
+- **State sync**: All mutations emit `"state-changed"` -> `editorStore.refreshState()` -> UI re-renders.
+- **Undo**: All layer operations automatically record undo entries via EditorService. Frontend just calls `undo()`/`redo()`.
+
+## Testing Strategy
+
+- **Domain**: Unit tests for `Layer::duplicate()`, `LayerStack::insert_layer()`, `LayerStack::index_of()`.
+- **Use cases**: Unit tests for `EditorService::duplicate_layer()`, `EditorService::add_layer_above()`.
+- **Frontend**: Component tests with mocked `invoke()` for LayersPanel interactions.

--- a/specs/010-layers-panel/research.md
+++ b/specs/010-layers-panel/research.md
@@ -1,0 +1,90 @@
+# Research: Layers Panel
+
+**Feature**: 010-layers-panel | **Date**: 2026-04-01
+
+## 1. Drag-and-Drop Library
+
+**Decision**: @dnd-kit/core + @dnd-kit/sortable
+
+**Rationale**:
+- Purpose-built for sortable lists in React, which is exactly the layer reorder use case.
+- Lightweight: ~15KB gzipped for core + sortable. Smallest viable option with proper DX.
+- Actively maintained (2024+), good TypeScript support.
+- Built-in visual feedback (drag overlay, sort animations) satisfies US4-AS2 ("visual indicator shows where the layer will be inserted").
+- Keyboard-accessible drag/drop out of the box.
+
+**Alternatives considered**:
+- **Native HTML5 DnD API**: No extra dependency, but requires significantly more code for drag previews, insertion indicators, and accessible keyboard reorder. Poor DX for a sortable list.
+- **@hello-pangea/dnd** (react-beautiful-dnd fork): ~30KB gzipped, heavier than needed. Maintained but more opinionated and larger.
+- **No library (pointer events + manual reorder)**: Maximum control but ~200+ lines of custom logic for a well-solved problem. Violates Simplicity principle.
+
+## 2. Layer Thumbnail Strategy
+
+**Decision**: Include raw RGBA data directly in `LayerInfoDto` via a `thumbnail` field (`Vec<u8>` / `number[]`).
+
+**Rationale**:
+- Minecraft textures are 16x16 to 64x64. Raw RGBA data per layer:
+  - 16x16 = 1,024 bytes (1KB)
+  - 32x32 = 4,096 bytes (4KB)
+  - 64x64 = 16,384 bytes (16KB)
+- For 50 layers at 16x16: ~50KB total per state update. Negligible for desktop IPC.
+- Eliminates need for a separate `get_layer_thumbnails` command and caching logic.
+- The frontend renders thumbnails by creating an `ImageData` from the RGBA array and drawing to a small `<canvas>` element.
+- Width/height come from `TextureMetadataDto` (all layers share texture dimensions).
+
+**Alternatives considered**:
+- **Separate `get_layer_thumbnails` command**: More efficient for large textures but adds complexity (cache invalidation, extra IPC). Over-engineering for Minecraft texture sizes.
+- **Base64 PNG encoding per layer**: Requires `image` crate in the DTO path or a separate encoding step. More bytes on the wire than raw RGBA for small images. Unnecessary.
+- **Frontend-only thumbnails from composite**: Not viable -- composite is the flattened result, not per-layer data.
+
+## 3. Layer List Rendering
+
+**Decision**: Simple `div` list with @dnd-kit `SortableContext`. No virtualization.
+
+**Rationale**:
+- SC-007 requires responsiveness with up to 50 layers.
+- 50 DOM nodes with simple content (icon + thumbnail canvas + text + opacity) is well within browser performance.
+- React 19 handles list re-renders efficiently.
+- Virtualization (@tanstack/virtual or react-window) adds complexity with no measurable benefit at this scale.
+
+**Alternatives considered**:
+- **@tanstack/react-virtual**: Would add ~3KB for zero perceptible gain at <=50 items. Complicates @dnd-kit integration.
+
+## 4. Inline Rename Pattern
+
+**Decision**: Controlled `<input>` element that replaces the name text on double-click or F2.
+
+**Rationale**:
+- React's controlled input pattern provides clean state management and event handling.
+- `onKeyDown` handles Enter (confirm) and Escape (cancel).
+- `onBlur` confirms the rename (spec US5-AS5).
+- Input is pre-filled with current name and auto-selected on mount.
+- Validation: empty names rejected client-side (no IPC call), backend also validates via `DomainError::EmptyName`.
+
+**Alternatives considered**:
+- **`contentEditable` on the name span**: Inconsistent browser behavior for selection, blur events, and IME input. Harder to control.
+- **Modal/dialog**: Violates the spec's "inline text field" requirement.
+
+## 5. Backend Gaps Analysis
+
+The following backend additions are needed (the existing layer commands cover most of the spec):
+
+| Gap | Needed for | Solution |
+|-----|-----------|----------|
+| No `duplicate_layer` | FR-008, US2-AS3 | Add `Layer::duplicate()` (domain), `EditorService::duplicate_layer()` (use_cases), Tauri command (commands) |
+| `add_layer` appends to top | US2-AS1 wants "above active" | Add `LayerStack::insert_layer(index, layer)` + `EditorService::add_layer_above()`, modify command to use active layer position |
+| No `index_of` on LayerStack | Needed by duplicate and add-above | Add `LayerStack::index_of(id) -> Option<usize>` |
+| No thumbnail in DTO | FR-003 (thumbnail preview) | Add `thumbnail: Vec<u8>` to `LayerInfoDto`, populate from `layer.buffer().clone_data()` |
+| Min-one-layer guard | FR-007, US2-AS4 | Enforce in `remove_layer` command: reject if `layer_stack.len() == 1` |
+
+## 6. UI Design Reference
+
+The `.pen` design file (`ui-design`, component `Panel-Layers`) specifies:
+
+- **Panel background**: `#252525` (= `colors.panelBody`)
+- **Header**: 28px, `#2A2A2A` (= `colors.panelHeader`), grip icon + "Layers" title
+- **Layer row**: 30px height, 4px radius. Active: `#3A3A3A` (= `colors.selectedItem`). Inactive: transparent.
+- **Row contents**: eye icon (12px, accent blue when visible), 18x18 thumbnail, name (10px Inter), opacity % (8px Geist Mono, `#888888`)
+- **Blend mode section**: 28px, `#2A2A2A` background. Label "Blend" + dropdown (`#333333`, chevron-down icon)
+- **Action bar**: 28px, 3 buttons (24x24, `#333333` bg, 4px radius): plus, trash-2, copy icons (lucide)
+- **Icons**: All from lucide-react (already installed): `Eye`, `EyeOff`, `Plus`, `Trash2`, `Copy`, `ChevronDown`, `GripHorizontal`

--- a/specs/010-layers-panel/spec.md
+++ b/specs/010-layers-panel/spec.md
@@ -1,0 +1,167 @@
+# Feature Specification: Layers Panel
+
+**Feature Branch**: `010-layers-panel`  
+**Created**: 2026-04-01  
+**Status**: Draft  
+**Input**: GitHub Issue #10 — Layers panel (UI, drag reorder, visibility, opacity, blend mode)
+
+## Clarifications
+
+### Session 2026-04-01
+
+- Q: Blend mode dropdown placement — per-layer row or panel-level? → A: Panel-level, un seul dropdown appliqué au calque actif (standard Photoshop/Krita). Le design UI est mis à jour en conséquence.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View and Select Layers (Priority: P1)
+
+A texture creator opens a texture for editing and sees a dockable "Layers" panel listing all layers of the current texture. Each layer row shows a visibility icon, a thumbnail preview, the layer name, and its opacity value. The currently active layer is visually highlighted. The user clicks on a different layer row to make it the active layer.
+
+**Why this priority**: Layer visibility and selection is the foundational interaction — every other layer operation depends on the user being able to see and select layers.
+
+**Independent Test**: Can be fully tested by opening a multi-layer texture and verifying that all layers appear with correct metadata, and that clicking a layer changes the active selection.
+
+**Acceptance Scenarios**:
+
+1. **Given** a texture with 3 layers is open, **When** the user views the Layers panel, **Then** all 3 layers are listed in stack order (topmost layer first) with their name, thumbnail, visibility icon, and opacity value.
+2. **Given** the Layers panel is visible, **When** the user clicks on a non-active layer row, **Then** that layer becomes the active layer and its row is visually highlighted.
+3. **Given** a texture is open, **When** the Layers panel first appears, **Then** the previously active layer (or topmost layer if none) is highlighted.
+
+---
+
+### User Story 2 - Add, Delete, and Duplicate Layers (Priority: P1)
+
+A texture creator uses the action buttons at the bottom of the Layers panel to manage layers. They can add a new empty layer, delete the currently selected layer, or duplicate the selected layer. After each action, the layer list updates immediately.
+
+**Why this priority**: Creating and removing layers is essential for any multi-layer editing workflow — without this, the panel is read-only and offers no editing value.
+
+**Independent Test**: Can be fully tested by using each action button and verifying the layer list reflects the change, with the new or duplicated layer becoming active.
+
+**Acceptance Scenarios**:
+
+1. **Given** a texture is open, **When** the user clicks the "Add" button, **Then** a new empty layer is inserted above the active layer and becomes the new active layer.
+2. **Given** a texture with multiple layers is open and a layer is selected, **When** the user clicks the "Delete" button, **Then** the selected layer is removed and the nearest remaining layer becomes active.
+3. **Given** a texture with at least one layer, **When** the user clicks the "Duplicate" button, **Then** a copy of the active layer is inserted directly above it, with the name suffixed (e.g., "Base (copy)"), and becomes the new active layer.
+4. **Given** a texture with only one layer, **When** the user clicks the "Delete" button, **Then** the deletion is prevented and the user is informed that at least one layer must exist.
+
+---
+
+### User Story 3 - Toggle Layer Visibility (Priority: P2)
+
+A texture creator clicks the eye icon on a layer row to hide or show that layer on the canvas. Hidden layers remain in the list but are visually dimmed, and their content is not rendered on the canvas.
+
+**Why this priority**: Visibility toggling is a core compositing workflow — artists need to isolate layers for inspection and comparison.
+
+**Independent Test**: Can be fully tested by toggling a layer's visibility and verifying the canvas updates to show/hide that layer's content, and the eye icon reflects the current state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visible layer, **When** the user clicks its eye icon, **Then** the layer becomes hidden, its row is visually dimmed, and its content disappears from the canvas.
+2. **Given** a hidden layer, **When** the user clicks its eye icon, **Then** the layer becomes visible again, its row returns to normal appearance, and its content reappears on the canvas.
+3. **Given** a hidden layer, **When** the user selects it and draws, **Then** drawing operations still apply to the hidden layer (visibility does not affect editability).
+
+---
+
+### User Story 4 - Reorder Layers by Drag and Drop (Priority: P2)
+
+A texture creator drags a layer row to a different position in the list to change the layer stacking order. The canvas updates in real time to reflect the new order.
+
+**Why this priority**: Layer ordering directly affects the visual result of compositing — artists frequently rearrange layers during the creative process.
+
+**Independent Test**: Can be fully tested by dragging a layer from one position to another and verifying the list order and canvas rendering both update accordingly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a texture with 3+ layers, **When** the user drags a layer row to a new position, **Then** the layer list reorders to reflect the new position and the canvas re-renders with the updated stacking order.
+2. **Given** a drag operation is in progress, **When** the user moves the layer over other rows, **Then** a visual indicator shows where the layer will be inserted.
+3. **Given** a drag operation is in progress, **When** the user releases outside the valid drop area, **Then** the operation is cancelled and the original order is preserved.
+
+---
+
+### User Story 5 - Rename a Layer (Priority: P2)
+
+A texture creator renames a layer by double-clicking its name or pressing F2 while a layer is selected. An inline text field appears, and the new name is saved when the user presses Enter or clicks away.
+
+**Why this priority**: Meaningful layer names improve workflow organization, especially for textures with many layers.
+
+**Independent Test**: Can be fully tested by triggering rename mode, typing a new name, confirming, and verifying the name persists.
+
+**Acceptance Scenarios**:
+
+1. **Given** a layer is selected, **When** the user double-clicks its name, **Then** an inline text input appears pre-filled with the current name.
+2. **Given** a layer is selected, **When** the user presses F2, **Then** an inline text input appears pre-filled with the current name.
+3. **Given** the rename input is active, **When** the user presses Enter, **Then** the new name is saved and the input closes.
+4. **Given** the rename input is active, **When** the user presses Escape, **Then** the rename is cancelled and the original name is restored.
+5. **Given** the rename input is active, **When** the user clicks outside the input, **Then** the new name is saved and the input closes.
+
+---
+
+### User Story 6 - Change Layer Blend Mode (Priority: P3)
+
+A texture creator selects a blend mode from a panel-level dropdown (above or below the layer list) to change how the active layer composites with layers below it. Available modes include Normal, Multiply, Screen, and Overlay. The canvas updates immediately.
+
+**Why this priority**: Blend modes are important for advanced compositing but not required for basic layer editing workflows.
+
+**Independent Test**: Can be fully tested by changing a layer's blend mode and verifying the canvas renders the layer with the selected blending algorithm.
+
+**Acceptance Scenarios**:
+
+1. **Given** a layer is active, **When** the user opens the panel-level blend mode dropdown, **Then** the available options are: Normal, Multiply, Screen, Overlay, and the active layer's current mode is shown as selected.
+2. **Given** a layer with "Normal" blend mode is active, **When** the user selects "Multiply" from the dropdown, **Then** the blend mode changes and the canvas re-renders with Multiply compositing.
+3. **Given** a different layer is selected, **When** the user views the blend mode dropdown, **Then** it reflects the newly selected layer's blend mode.
+
+---
+
+### Edge Cases
+
+- What happens when the texture has no layers (empty state)? The panel shows an empty state message prompting the user to add a layer.
+- What happens when the user tries to rename a layer with an empty name? The rename is rejected and the previous name is kept.
+- What happens when many layers exist (e.g., 20+)? The layer list scrolls vertically; the header and action bar remain fixed.
+- What happens when the user selects a layer and then switches to a different texture? The panel updates to show the new texture's layers with its own active layer.
+- What happens when a layer is modified from outside the panel (e.g., via MCP)? The panel receives an event and updates to reflect the current state.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST display a dockable "Layers" panel that can be positioned within the panel layout system.
+- **FR-002**: System MUST list all layers of the currently active texture in stacking order (topmost first).
+- **FR-003**: Each layer row MUST display: a visibility toggle icon, a thumbnail preview, the layer name, and the opacity value.
+- **FR-004**: System MUST visually highlight the currently active layer.
+- **FR-005**: Users MUST be able to select a layer by clicking its row.
+- **FR-006**: Users MUST be able to add a new empty layer via an "Add" action button.
+- **FR-007**: Users MUST be able to delete the selected layer via a "Delete" action button, with a minimum of one layer enforced.
+- **FR-008**: Users MUST be able to duplicate the selected layer via a "Duplicate" action button.
+- **FR-009**: Users MUST be able to toggle layer visibility by clicking the eye icon.
+- **FR-010**: Users MUST be able to reorder layers via drag and drop within the list.
+- **FR-011**: Users MUST be able to rename a layer by double-clicking its name or pressing F2.
+- **FR-012**: System MUST provide a panel-level blend mode dropdown (applying to the active layer) with at least: Normal, Multiply, Screen, Overlay.
+- **FR-013**: All layer changes MUST synchronize with the backend state and update the canvas in real time.
+- **FR-014**: The layer list MUST scroll when the number of layers exceeds the panel height, while the header and action bar remain fixed.
+
+### Key Entities
+
+- **Layer**: A single compositing layer within a texture. Key attributes: name, visibility, opacity, blend mode, stacking position, pixel data (thumbnail derived from this).
+- **Layer List**: Ordered collection of layers belonging to the active texture, rendered in stacking order.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can view all layers of a texture and identify the active layer within 1 second of opening the panel.
+- **SC-002**: Users can add, delete, or duplicate a layer with a single click, and the panel and canvas update within 500ms.
+- **SC-003**: Users can reorder layers via drag and drop, with the canvas reflecting the new order immediately upon drop.
+- **SC-004**: Users can toggle layer visibility with a single click, with the canvas updating instantly.
+- **SC-005**: Users can rename a layer in place in under 3 seconds (trigger + type + confirm).
+- **SC-006**: Users can change a layer's blend mode from a dropdown, with the canvas reflecting the change immediately.
+- **SC-007**: The panel remains responsive and scrollable with up to 50 layers.
+
+## Assumptions
+
+- The dockable panel system is already implemented (dependency: #7, completed).
+- Backend layer Tauri commands exist or will be available (dependency: #5) — this feature depends on those commands for state synchronization.
+- Layer thumbnail generation is handled by the backend; the frontend receives an image representation to display.
+- The panel follows the existing dark theme and design tokens established in the UI design (`ui-design` — component/Panel-Layers).
+- Blend modes beyond Normal, Multiply, Screen, and Overlay may be added in future iterations but are out of scope for this feature.
+- Opacity editing (changing the value, not just displaying it) is out of scope — this panel displays the current opacity value but does not provide a slider or input to change it.
+- Layer effects, masks, and grouping are out of scope for this feature.

--- a/specs/010-layers-panel/tasks.md
+++ b/specs/010-layers-panel/tasks.md
@@ -1,0 +1,225 @@
+# Tasks: Layers Panel
+
+**Input**: Design documents from `/specs/010-layers-panel/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/ipc.md, quickstart.md
+
+**Tests**: Domain and use case unit tests are included (constitution mandate IV: Test-First for Domain). Frontend component tests are not included (not explicitly requested).
+
+**Organization**: Tasks are grouped by user story. Backend foundational work is grouped in Phase 2 because it touches shared files (`dto.rs`, `layer_commands.rs`, `lib.rs`) and must be complete before frontend stories.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Install new frontend dependency
+
+- [x] T001 Install @dnd-kit/core and @dnd-kit/sortable via npm in package.json
+
+---
+
+## Phase 2: Foundational (Backend — All Layer Operations)
+
+**Purpose**: Extend backend with domain methods, use case orchestration, DTO changes, and Tauri commands needed across multiple user stories. All domain/use_case methods include unit tests per constitution principle IV.
+
+**Why grouped**: These tasks modify shared Rust files (`dto.rs`, `layer_commands.rs`, `lib.rs`). Completing them together avoids repeated file edits and ensures the backend compiles before any frontend work begins.
+
+- [x] T002 [P] Add `insert_layer(index, layer)` and `index_of(id)` methods with unit tests to LayerStack in src-tauri/src/domain/layer_stack.rs
+- [x] T003 [P] Add `duplicate(new_id)` method with unit tests to Layer in src-tauri/src/domain/layer.rs
+- [x] T004 Add `add_layer_above(id, name, above_id)` and `duplicate_layer(source_id, new_id)` methods with unit tests to EditorService in src-tauri/src/use_cases/editor_service.rs
+- [x] T005 [P] Add `thumbnail: Vec<u8>` field to LayerInfoDto and populate from `layer.buffer().clone_data()` in `From<&Layer>` in src-tauri/src/commands/dto.rs
+- [x] T006 Modify `add_layer` command to insert above active layer and add min-1-layer guard to `remove_layer` command in src-tauri/src/commands/layer_commands.rs
+- [x] T007 Add `duplicate_layer` Tauri command and register in `generate_handler!` in src-tauri/src/commands/layer_commands.rs and src-tauri/src/lib.rs
+- [x] T008 Update `LayerInfoDto` type (add `thumbnail: number[]`) and add `duplicateLayer(layerId)` wrapper in src/api/commands.ts
+
+**Checkpoint**: `cargo test` passes, `npm run typecheck` passes. All backend layer operations are available via IPC.
+
+---
+
+## Phase 3: User Story 1 — View and Select Layers (Priority: P1) MVP
+
+**Goal**: Display a dockable "Layers" panel listing all layers with thumbnails, names, opacity, and visibility state. Users can select a layer by clicking its row.
+
+**Independent Test**: Open a multi-layer texture, verify all layers appear in stacking order (topmost first) with correct metadata. Click a layer row to change the active selection.
+
+### Implementation for User Story 1
+
+- [x] T009 [US1] Create LayerRow component rendering inline thumbnail canvas (18x18), layer name, opacity percentage, visibility icon (Eye/EyeOff), and active highlight style in src/components/layers/LayerRow.tsx
+- [x] T010 [US1] Create LayersPanel component with scrollable layer list (reversed stacking order — topmost first), layer click-to-select dispatching to editorStore, empty state message, and panel layout (fixed header area + scrollable list + fixed bottom area) in src/components/layers/LayersPanel.tsx
+- [x] T011 [US1] Update panels/LayersPanel.tsx to be thin dockview wrapper delegating to layers/LayersPanel (same pattern as CanvasViewportPanel) in src/components/panels/LayersPanel.tsx
+
+**Checkpoint**: Layers panel displays all layers of the active texture with thumbnails, names, opacity. Clicking a layer selects it. Empty state shown when no texture is open.
+
+---
+
+## Phase 4: User Story 2 — Add, Delete, and Duplicate Layers (Priority: P1)
+
+**Goal**: Users can add, delete, or duplicate layers via action buttons at the bottom of the panel. New/duplicated layers are inserted above the active layer.
+
+**Independent Test**: Use each action button and verify: add creates empty layer above active, duplicate copies active layer with "(copy)" suffix, delete removes active layer (blocked if last layer). Panel and canvas update after each action.
+
+### Implementation for User Story 2
+
+- [x] T012 [US2] Add action bar with Add (Plus icon), Delete (Trash2 icon), and Duplicate (Copy icon) buttons calling addLayer, removeLayer, and duplicateLayer API commands, with last-layer deletion prevention, in src/components/layers/LayersPanel.tsx
+
+**Checkpoint**: Add/Delete/Duplicate buttons work. New layers appear above active. Last layer cannot be deleted. All actions are undoable.
+
+---
+
+## Phase 5: User Story 3 — Toggle Layer Visibility (Priority: P2)
+
+**Goal**: Users can toggle layer visibility by clicking the eye icon. Hidden layers are visually dimmed, and the canvas updates.
+
+**Independent Test**: Click eye icon on a visible layer — it hides (row dimmed, canvas updates). Click again — it reappears.
+
+### Implementation for User Story 3
+
+- [x] T013 [US3] Add visibility toggle click handler on eye icon calling setLayerVisibility, and apply dimmed row style for hidden layers in src/components/layers/LayerRow.tsx
+
+**Checkpoint**: Eye icon toggles visibility. Hidden layers are dimmed. Canvas reflects visibility changes.
+
+---
+
+## Phase 6: User Story 4 — Reorder Layers by Drag and Drop (Priority: P2)
+
+**Goal**: Users can drag layer rows to reorder them. The canvas updates in real time to reflect the new stacking order.
+
+**Independent Test**: Drag a layer from one position to another — list reorders and canvas re-renders. Cancel a drag outside the list — original order preserved.
+
+### Implementation for User Story 4
+
+- [x] T014 [US4] Integrate @dnd-kit DndContext and SortableContext in LayersPanel, make LayerRow a useSortable item, add drag overlay and insertion indicator, convert visual indices (0=top) to backend indices (0=bottom) before calling moveLayer on drag end in src/components/layers/LayersPanel.tsx and src/components/layers/LayerRow.tsx
+
+**Checkpoint**: Layers can be reordered by drag-and-drop. Visual insertion indicator shown during drag. Canvas updates after drop.
+
+---
+
+## Phase 7: User Story 5 — Rename a Layer (Priority: P2)
+
+**Goal**: Users can rename a layer by double-clicking its name or pressing F2. An inline text input appears, confirmed by Enter or blur, cancelled by Escape.
+
+**Independent Test**: Double-click a layer name — input appears with current name pre-filled. Type new name, press Enter — name updates. Press Escape — original name restored.
+
+### Implementation for User Story 5
+
+- [x] T015 [US5] Add inline rename mode triggered by double-click and F2 with controlled input, Enter to confirm (calls setLayerName), Escape to cancel, blur to confirm, and empty name rejection in src/components/layers/LayerRow.tsx
+
+**Checkpoint**: Rename works via double-click and F2. Enter/blur saves, Escape cancels. Empty name rejected.
+
+---
+
+## Phase 8: User Story 6 — Change Layer Blend Mode (Priority: P3)
+
+**Goal**: Users can select a blend mode from a panel-level dropdown that applies to the active layer.
+
+**Independent Test**: Select a layer, open blend mode dropdown — shows Normal/Multiply/Screen/Overlay with current mode selected. Change mode — canvas re-renders with new blending.
+
+### Implementation for User Story 6
+
+- [x] T016 [US6] Create BlendModeSelect dropdown component (Normal/Multiply/Screen/Overlay) in src/components/layers/BlendModeSelect.tsx
+- [x] T017 [US6] Integrate BlendModeSelect in LayersPanel between layer list and action bar, reflecting active layer's blend mode and calling setLayerBlendMode on change in src/components/layers/LayersPanel.tsx
+
+**Checkpoint**: Blend mode dropdown shows active layer's mode. Changing mode updates canvas compositing immediately.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Edge cases and final verification
+
+- [x] T018 Verify all spec edge cases: empty state message, empty name rejection, 20+ layers scroll with fixed header/action bar, texture switch updates panel, external MCP mutations trigger panel refresh
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup. T002 and T003 are parallel. T004 depends on T002+T003. T005 is parallel with T002/T003. T006 and T007 depend on T004. T008 depends on T005+T007.
+- **User Stories (Phase 3+)**: All depend on Foundational (Phase 2) completion
+- **Polish (Phase 9)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Phase 2 — No dependencies on other stories
+- **US2 (P1)**: Can start after US1 (T010 creates the panel layout that T012 modifies)
+- **US3 (P2)**: Can start after US1 (needs LayerRow) — No dependencies on US2/US4/US5/US6
+- **US4 (P2)**: Can start after US1 (needs panel + rows) — No dependencies on US2/US3/US5/US6
+- **US5 (P2)**: Can start after US1 (needs LayerRow) — No dependencies on US2/US3/US4/US6
+- **US6 (P3)**: Can start after US1 (needs panel layout) — No dependencies on US2-US5
+
+### Within Each User Story
+
+- Backend infrastructure complete before frontend (Phase 2 before Phase 3+)
+- US1 creates the panel structure that all other stories build on
+- US3, US4, US5, US6 modify files created by US1 but touch distinct areas (visibility icon, DnD wrapper, rename input, blend dropdown)
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel (different domain files)
+- T005 can run in parallel with T002/T003 (different file: dto.rs)
+- After US1, stories US3/US4/US5/US6 touch different concerns and could theoretically be developed in parallel by different developers
+- T016 and T017 (US6) are sequential but could be parallelized with US3/US4/US5
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```
+# Parallel batch 1 (different domain files):
+T002: LayerStack::insert_layer(), index_of() in domain/layer_stack.rs
+T003: Layer::duplicate() in domain/layer.rs
+T005: LayerInfoDto thumbnail in commands/dto.rs
+
+# Sequential after batch 1:
+T004: EditorService methods in use_cases/editor_service.rs (depends on T002+T003)
+
+# Sequential after T004:
+T006: Modify add_layer + guard remove_layer in commands/layer_commands.rs
+T007: Add duplicate_layer command + register in lib.rs
+
+# After T005+T007:
+T008: Frontend API type + wrapper in api/commands.ts
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2 Only)
+
+1. Complete Phase 1: Setup (@dnd-kit install)
+2. Complete Phase 2: Foundational (all backend changes)
+3. Complete Phase 3: US1 — View and Select Layers
+4. Complete Phase 4: US2 — Add, Delete, Duplicate
+5. **STOP and VALIDATE**: Panel shows layers, selection works, CRUD works
+6. This is the minimum viable Layers Panel
+
+### Incremental Delivery
+
+1. Setup + Foundational -> Backend ready
+2. Add US1 -> Layers visible, selectable -> Validate
+3. Add US2 -> CRUD operations -> Validate (MVP!)
+4. Add US3 -> Visibility toggle -> Validate
+5. Add US4 -> Drag reorder -> Validate
+6. Add US5 -> Rename -> Validate
+7. Add US6 -> Blend modes -> Validate
+8. Polish -> Edge cases verified -> Feature complete
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks
+- [Story] label maps task to specific user story from spec.md
+- Layer list displayed in reverse order (topmost layer first, but LayerStack stores bottom-first)
+- All layer commands return `EditorStateDto` — the panel re-renders from store, no manual state management
+- Theme tokens from `src/styles/theme.ts` — use `colors.*`, `fonts.*`, `fontSizes.*`
+- Icons from `lucide-react` (already installed): Eye, EyeOff, Plus, Trash2, Copy, ChevronDown, GripHorizontal
+- UI design reference: `ui-design` .pen file, component `Panel-Layers`

--- a/src-tauri/src/commands/dto.rs
+++ b/src-tauri/src/commands/dto.rs
@@ -25,7 +25,7 @@ pub struct TextureMetadataDto {
     pub dirty: bool,
 }
 
-/// Layer metadata without pixel data.
+/// Layer metadata with thumbnail pixel data.
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LayerInfoDto {
@@ -35,6 +35,7 @@ pub struct LayerInfoDto {
     pub blend_mode: String,
     pub visible: bool,
     pub locked: bool,
+    pub thumbnail: Vec<u8>,
 }
 
 /// Composited pixel data for canvas rendering.
@@ -99,6 +100,7 @@ impl From<&Layer> for LayerInfoDto {
             blend_mode: blend_mode_to_str(layer.blend_mode()),
             visible: layer.is_visible(),
             locked: layer.is_locked(),
+            thumbnail: layer.buffer().clone_data(),
         }
     }
 }

--- a/src-tauri/src/commands/layer_commands.rs
+++ b/src-tauri/src/commands/layer_commands.rs
@@ -21,7 +21,10 @@ pub fn add_layer(
         .map_err(|_| AppError::Internal("state lock poisoned".into()))?;
 
     let layer_id = LayerId::new(uuid::Uuid::new_v4().as_u128());
-    state.editor_mut()?.add_layer(layer_id, &name)?;
+    let above_id = state.active_layer_id;
+    state
+        .editor_mut()?
+        .add_layer_above(layer_id, &name, above_id)?;
     state.active_layer_id = Some(layer_id);
     let dto = build_editor_state_dto(state.editor.as_ref(), state.active_layer_id);
 
@@ -41,15 +44,29 @@ pub fn remove_layer(
         .lock()
         .map_err(|_| AppError::Internal("state lock poisoned".into()))?;
 
+    let stack = state.editor_ref()?.texture().layer_stack();
+    if stack.len() <= 1 {
+        return Err(AppError::Validation(
+            "Cannot delete the last layer".to_string(),
+        ));
+    }
+
+    // Remember position before removal to select the nearest layer afterwards
+    let removed_index = stack.index_of(parsed_id);
+
     state.editor_mut()?.remove_layer(parsed_id)?;
 
-    // Clear active_layer_id if the removed layer was active
+    // Select nearest remaining layer if the removed layer was active
     if state.active_layer_id == Some(parsed_id) {
-        state.active_layer_id = state
-            .editor_ref()
-            .ok()
-            .and_then(|e| e.texture().layer_stack().layers().first())
-            .map(|l| l.id());
+        let layers = state.editor_ref()?.texture().layer_stack().layers();
+        state.active_layer_id = if layers.is_empty() {
+            None
+        } else {
+            let nearest = removed_index
+                .unwrap_or(0)
+                .min(layers.len().saturating_sub(1));
+            Some(layers[nearest].id())
+        };
     }
 
     let dto = build_editor_state_dto(state.editor.as_ref(), state.active_layer_id);
@@ -152,6 +169,27 @@ pub fn set_layer_name(
         .map_err(|_| AppError::Internal("state lock poisoned".into()))?;
 
     state.editor_mut()?.set_layer_name(parsed_id, &name)?;
+    let dto = build_editor_state_dto(state.editor.as_ref(), state.active_layer_id);
+
+    emit_state_changed(&app);
+    Ok(dto)
+}
+
+#[tauri::command]
+pub fn duplicate_layer(
+    app: AppHandle,
+    state: State<'_, Mutex<AppState>>,
+    layer_id: String,
+) -> Result<EditorStateDto, AppError> {
+    let parsed_id = parse_layer_id(&layer_id)?;
+    let new_id = LayerId::new(uuid::Uuid::new_v4().as_u128());
+
+    let mut state = state
+        .lock()
+        .map_err(|_| AppError::Internal("state lock poisoned".into()))?;
+
+    state.editor_mut()?.duplicate_layer(parsed_id, new_id)?;
+    state.active_layer_id = Some(new_id);
     let dto = build_editor_state_dto(state.editor.as_ref(), state.active_layer_id);
 
     emit_state_changed(&app);

--- a/src-tauri/src/domain/layer.rs
+++ b/src-tauri/src/domain/layer.rs
@@ -116,6 +116,26 @@ impl Layer {
         self.blend_mode = mode;
     }
 
+    /// Creates a copy of this layer with the given ID and " (copy)" name suffix.
+    /// The duplicate is always unlocked regardless of the source layer's lock state.
+    pub fn duplicate(&self, new_id: LayerId) -> Result<Self, DomainError> {
+        let name = format!("{} (copy)", self.name);
+        let buffer = PixelBuffer::from_raw_parts(
+            self.buffer.width(),
+            self.buffer.height(),
+            self.buffer.clone_data(),
+        )?;
+        Ok(Self {
+            id: new_id,
+            name,
+            buffer,
+            opacity: self.opacity,
+            blend_mode: self.blend_mode,
+            visible: self.visible,
+            locked: false,
+        })
+    }
+
     pub fn set_name(&mut self, name: String) -> Result<(), DomainError> {
         if name.is_empty() {
             return Err(DomainError::EmptyName);
@@ -273,6 +293,35 @@ mod tests {
         let buf = layer.buffer_mut().unwrap();
         buf.set_pixel(0, 0, Color::WHITE).unwrap();
         assert_eq!(layer.buffer().get_pixel(0, 0).unwrap(), Color::WHITE);
+    }
+
+    #[test]
+    fn duplicate_copies_all_properties() {
+        let mut layer = test_layer();
+        layer.set_opacity(0.5);
+        layer.set_blend_mode(BlendMode::Multiply);
+        layer.set_visible(false);
+        layer.set_locked(true);
+        let dup = layer.duplicate(LayerId::new(99)).unwrap();
+        assert_eq!(dup.id(), LayerId::new(99));
+        assert_eq!(dup.name(), "test (copy)");
+        assert_eq!(dup.opacity(), 0.5);
+        assert_eq!(dup.blend_mode(), BlendMode::Multiply);
+        assert!(!dup.is_visible());
+        assert!(
+            !dup.is_locked(),
+            "duplicate must be unlocked regardless of source"
+        );
+    }
+
+    #[test]
+    fn duplicate_deep_copies_buffer() {
+        let mut layer = test_layer();
+        layer.set_pixel(1, 1, Color::WHITE).unwrap();
+        let dup = layer.duplicate(LayerId::new(2)).unwrap();
+        assert_eq!(dup.buffer().get_pixel(1, 1).unwrap(), Color::WHITE);
+        assert_eq!(dup.buffer().width(), 4);
+        assert_eq!(dup.buffer().height(), 4);
     }
 
     #[test]

--- a/src-tauri/src/domain/layer_stack.rs
+++ b/src-tauri/src/domain/layer_stack.rs
@@ -20,6 +20,19 @@ impl LayerStack {
         self.layers.push(layer);
     }
 
+    pub fn insert_layer(&mut self, index: usize, layer: Layer) -> Result<(), DomainError> {
+        let len = self.layers.len();
+        if index > len {
+            return Err(DomainError::InvalidIndex { index, len });
+        }
+        self.layers.insert(index, layer);
+        Ok(())
+    }
+
+    pub fn index_of(&self, id: LayerId) -> Option<usize> {
+        self.layers.iter().position(|l| l.id() == id)
+    }
+
     pub fn remove_layer(&mut self, id: LayerId) -> Result<Layer, DomainError> {
         let pos =
             self.layers
@@ -368,6 +381,60 @@ mod tests {
         stack.add_layer(make_layer(42, "target", 2, 2));
         assert!(stack.get_layer(LayerId::new(42)).is_some());
         assert!(stack.get_layer(LayerId::new(99)).is_none());
+    }
+
+    #[test]
+    fn insert_layer_at_beginning() {
+        let mut stack = LayerStack::new();
+        stack.add_layer(make_layer(1, "a", 2, 2));
+        stack.insert_layer(0, make_layer(2, "b", 2, 2)).unwrap();
+        assert_eq!(stack.layers()[0].name(), "b");
+        assert_eq!(stack.layers()[1].name(), "a");
+    }
+
+    #[test]
+    fn insert_layer_at_end() {
+        let mut stack = LayerStack::new();
+        stack.add_layer(make_layer(1, "a", 2, 2));
+        stack.insert_layer(1, make_layer(2, "b", 2, 2)).unwrap();
+        assert_eq!(stack.layers()[0].name(), "a");
+        assert_eq!(stack.layers()[1].name(), "b");
+    }
+
+    #[test]
+    fn insert_layer_in_middle() {
+        let mut stack = LayerStack::new();
+        stack.add_layer(make_layer(1, "a", 2, 2));
+        stack.add_layer(make_layer(2, "c", 2, 2));
+        stack.insert_layer(1, make_layer(3, "b", 2, 2)).unwrap();
+        assert_eq!(stack.layers()[0].name(), "a");
+        assert_eq!(stack.layers()[1].name(), "b");
+        assert_eq!(stack.layers()[2].name(), "c");
+    }
+
+    #[test]
+    fn insert_layer_out_of_bounds() {
+        let mut stack = LayerStack::new();
+        stack.add_layer(make_layer(1, "a", 2, 2));
+        let err = stack.insert_layer(5, make_layer(2, "b", 2, 2)).unwrap_err();
+        assert_eq!(err, DomainError::InvalidIndex { index: 5, len: 1 });
+    }
+
+    #[test]
+    fn index_of_existing_layer() {
+        let mut stack = LayerStack::new();
+        stack.add_layer(make_layer(1, "a", 2, 2));
+        stack.add_layer(make_layer(2, "b", 2, 2));
+        stack.add_layer(make_layer(3, "c", 2, 2));
+        assert_eq!(stack.index_of(LayerId::new(1)), Some(0));
+        assert_eq!(stack.index_of(LayerId::new(2)), Some(1));
+        assert_eq!(stack.index_of(LayerId::new(3)), Some(2));
+    }
+
+    #[test]
+    fn index_of_missing_layer() {
+        let stack = LayerStack::new();
+        assert_eq!(stack.index_of(LayerId::new(99)), None);
     }
 
     #[test]

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -6,6 +6,9 @@ use crate::domain::DomainError;
 pub enum AppError {
     #[error("{0}")]
     Internal(String),
+
+    #[error("{0}")]
+    Validation(String),
 }
 
 impl serde::Serialize for AppError {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,7 @@ pub fn run() {
             commands::set_layer_blend_mode,
             commands::set_layer_name,
             commands::set_layer_locked,
+            commands::duplicate_layer,
             commands::undo,
             commands::redo,
             commands::get_editor_state,

--- a/src-tauri/src/use_cases/editor_service.rs
+++ b/src-tauri/src/use_cases/editor_service.rs
@@ -43,6 +43,7 @@ impl EditorService {
     }
 
     /// Direct mutation access WITHOUT undo tracking.
+    /// Callers are responsible for capturing a snapshot before mutating if undo is required.
     pub(crate) fn texture_mut(&mut self) -> &mut Texture {
         &mut self.texture
     }
@@ -267,6 +268,65 @@ impl EditorService {
     pub fn add_layer(&mut self, id: LayerId, name: &str) -> Result<(), DomainError> {
         let snapshot = TextureSnapshot::capture(self.texture.layer_stack());
         self.texture.add_layer(id, name.to_string())?;
+        self.undo_manager
+            .push(UndoEntry::new(OperationType::LayerAdd, snapshot));
+        Ok(())
+    }
+
+    pub fn add_layer_above(
+        &mut self,
+        id: LayerId,
+        name: &str,
+        above_id: Option<LayerId>,
+    ) -> Result<(), DomainError> {
+        let layer = Layer::new(
+            id,
+            name.to_string(),
+            self.texture.width(),
+            self.texture.height(),
+        )?;
+        // Snapshot after validation to avoid unnecessary allocation on failure
+        let snapshot = TextureSnapshot::capture(self.texture.layer_stack());
+        match above_id {
+            Some(ref_id) => {
+                let index = self.texture.layer_stack().index_of(ref_id).ok_or(
+                    DomainError::LayerNotFound {
+                        layer_id: ref_id.value(),
+                    },
+                )?;
+                self.texture
+                    .layer_stack_mut()
+                    .insert_layer(index + 1, layer)?;
+            }
+            None => {
+                self.texture.layer_stack_mut().add_layer(layer);
+            }
+        }
+        self.texture.mark_dirty();
+        self.undo_manager
+            .push(UndoEntry::new(OperationType::LayerAdd, snapshot));
+        Ok(())
+    }
+
+    pub fn duplicate_layer(
+        &mut self,
+        source_id: LayerId,
+        new_id: LayerId,
+    ) -> Result<(), DomainError> {
+        let index =
+            self.texture
+                .layer_stack()
+                .index_of(source_id)
+                .ok_or(DomainError::LayerNotFound {
+                    layer_id: source_id.value(),
+                })?;
+        let duplicate = self.texture.layer_stack().layers()[index].duplicate(new_id)?;
+        // Snapshot after validation to avoid unnecessary allocation on failure
+        let snapshot = TextureSnapshot::capture(self.texture.layer_stack());
+        self.texture
+            .layer_stack_mut()
+            .insert_layer(index + 1, duplicate)?;
+        self.texture.mark_dirty();
         self.undo_manager
             .push(UndoEntry::new(OperationType::LayerAdd, snapshot));
         Ok(())
@@ -1281,5 +1341,135 @@ mod tests {
         let data = writer.data.borrow();
         // First pixel should be white (255,255,255,255)
         assert_eq!(&data[0..4], &[255, 255, 255, 255]);
+    }
+
+    // === Layers Panel: add_layer_above, duplicate_layer ===
+
+    #[test]
+    fn add_layer_above_inserts_after_reference() {
+        let mut svc = test_service();
+        let id1 = LayerId::new(1);
+        svc.add_layer(LayerId::new(2), "top").unwrap();
+
+        svc.add_layer_above(LayerId::new(3), "middle", Some(id1))
+            .unwrap();
+
+        let names: Vec<&str> = svc
+            .texture()
+            .layer_stack()
+            .layers()
+            .iter()
+            .map(|l| l.name())
+            .collect();
+        assert_eq!(names, vec!["base", "middle", "top"]);
+    }
+
+    #[test]
+    fn add_layer_above_none_appends_to_top() {
+        let mut svc = test_service();
+        svc.add_layer_above(LayerId::new(2), "new_top", None)
+            .unwrap();
+
+        let last = svc.texture().layer_stack().layers().last().unwrap();
+        assert_eq!(last.name(), "new_top");
+    }
+
+    #[test]
+    fn add_layer_above_is_undoable() {
+        let mut svc = test_service();
+        let id1 = LayerId::new(1);
+        svc.add_layer_above(LayerId::new(2), "above", Some(id1))
+            .unwrap();
+        assert_eq!(svc.texture().layer_stack().len(), 2);
+
+        svc.undo().unwrap();
+        assert_eq!(svc.texture().layer_stack().len(), 1);
+    }
+
+    #[test]
+    fn add_layer_above_missing_reference_returns_error() {
+        let mut svc = test_service();
+        let err = svc
+            .add_layer_above(LayerId::new(2), "nope", Some(LayerId::new(999)))
+            .unwrap_err();
+        assert_eq!(err, DomainError::LayerNotFound { layer_id: 999 });
+    }
+
+    #[test]
+    fn duplicate_layer_copies_above_source() {
+        let mut svc = test_service();
+        let id1 = LayerId::new(1);
+        svc.add_layer(LayerId::new(2), "top").unwrap();
+
+        svc.duplicate_layer(id1, LayerId::new(3)).unwrap();
+
+        let names: Vec<&str> = svc
+            .texture()
+            .layer_stack()
+            .layers()
+            .iter()
+            .map(|l| l.name())
+            .collect();
+        assert_eq!(names, vec!["base", "base (copy)", "top"]);
+    }
+
+    #[test]
+    fn duplicate_layer_copies_pixel_data() {
+        let mut svc = test_service();
+        let id1 = LayerId::new(1);
+        let mut tool = BrushTool::default();
+        brush_stroke(&mut svc, &mut tool, id1, 0, 0, Color::WHITE);
+
+        svc.duplicate_layer(id1, LayerId::new(2)).unwrap();
+
+        let dup = svc
+            .texture()
+            .layer_stack()
+            .get_layer(LayerId::new(2))
+            .unwrap();
+        assert_eq!(dup.buffer().get_pixel(0, 0).unwrap(), Color::WHITE);
+    }
+
+    #[test]
+    fn duplicate_layer_is_undoable() {
+        let mut svc = test_service();
+        svc.duplicate_layer(LayerId::new(1), LayerId::new(2))
+            .unwrap();
+        assert_eq!(svc.texture().layer_stack().len(), 2);
+
+        svc.undo().unwrap();
+        assert_eq!(svc.texture().layer_stack().len(), 1);
+    }
+
+    #[test]
+    fn duplicate_layer_missing_source_returns_error() {
+        let mut svc = test_service();
+        let err = svc
+            .duplicate_layer(LayerId::new(999), LayerId::new(2))
+            .unwrap_err();
+        assert_eq!(err, DomainError::LayerNotFound { layer_id: 999 });
+    }
+
+    #[test]
+    fn set_layer_name_empty_returns_error_without_undo_entry() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let err = svc.set_layer_name(id, "").unwrap_err();
+        assert_eq!(err, DomainError::EmptyName);
+        assert!(!svc.can_undo(), "failed rename must not push undo entry");
+    }
+
+    #[test]
+    fn duplicate_layer_is_unlocked() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        svc.set_layer_locked(id, true).unwrap();
+        svc.duplicate_layer(id, LayerId::new(2)).unwrap();
+        let dup = svc
+            .texture()
+            .layer_stack()
+            .get_layer(LayerId::new(2))
+            .unwrap();
+        assert!(!dup.is_locked(), "duplicated layer must be unlocked");
     }
 }

--- a/src/api/commands.ts
+++ b/src/api/commands.ts
@@ -27,6 +27,8 @@ export interface LayerInfoDto {
   blendMode: BlendMode;
   visible: boolean;
   locked: boolean;
+  /** Raw RGBA bytes (u8 0–255), length = width * height * 4. Dimensions from TextureMetadataDto. */
+  thumbnail: number[];
 }
 
 export interface CompositeDto {
@@ -188,6 +190,10 @@ export function setLayerBlendMode(
 
 export function setLayerName(layerId: string, name: string): Promise<EditorStateDto> {
   return invoke("set_layer_name", { layerId, name });
+}
+
+export function duplicateLayer(layerId: string): Promise<EditorStateDto> {
+  return invoke("duplicate_layer", { layerId });
 }
 
 export function setLayerLocked(

--- a/src/components/layers/BlendModeSelect.test.tsx
+++ b/src/components/layers/BlendModeSelect.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BlendModeSelect } from "./BlendModeSelect";
+
+afterEach(cleanup);
+
+describe("BlendModeSelect", () => {
+  it("renders all four blend modes", () => {
+    render(<BlendModeSelect value="normal" onChange={() => {}} />);
+    const select = screen.getByRole("combobox");
+    const options = select.querySelectorAll("option");
+    expect(options).toHaveLength(4);
+    expect(options[0].textContent).toBe("Normal");
+    expect(options[1].textContent).toBe("Multiply");
+    expect(options[2].textContent).toBe("Screen");
+    expect(options[3].textContent).toBe("Overlay");
+  });
+
+  it("reflects the current value", () => {
+    render(<BlendModeSelect value="multiply" onChange={() => {}} />);
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(select.value).toBe("multiply");
+  });
+
+  it("calls onChange when user selects a different mode", () => {
+    const onChange = vi.fn();
+    render(<BlendModeSelect value="normal" onChange={onChange} />);
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, { target: { value: "screen" } });
+    expect(onChange).toHaveBeenCalledWith("screen");
+  });
+
+  it("displays the Blend label", () => {
+    render(<BlendModeSelect value="normal" onChange={() => {}} />);
+    expect(screen.getByText("Blend")).toBeDefined();
+  });
+});

--- a/src/components/layers/BlendModeSelect.tsx
+++ b/src/components/layers/BlendModeSelect.tsx
@@ -1,0 +1,92 @@
+import { ChevronDown } from "lucide-react";
+import type { BlendMode } from "../../api/commands";
+import { colors, fontSizes, fonts } from "../../styles/theme";
+
+const BLEND_MODES: { value: BlendMode; label: string }[] = [
+  { value: "normal", label: "Normal" },
+  { value: "multiply", label: "Multiply" },
+  { value: "screen", label: "Screen" },
+  { value: "overlay", label: "Overlay" },
+];
+
+const VALID_BLEND_MODES = new Set<string>(BLEND_MODES.map((m) => m.value));
+
+function isBlendMode(value: string): value is BlendMode {
+  return VALID_BLEND_MODES.has(value);
+}
+
+interface BlendModeSelectProps {
+  value: BlendMode;
+  onChange: (mode: BlendMode) => void;
+}
+
+export function BlendModeSelect({ value, onChange }: BlendModeSelectProps) {
+  return (
+    <div style={containerStyle}>
+      <span style={labelStyle}>Blend</span>
+      <div style={selectWrapperStyle}>
+        <select
+          style={selectStyle}
+          value={value}
+          onChange={(e) => {
+            if (isBlendMode(e.target.value)) onChange(e.target.value);
+          }}
+        >
+          {BLEND_MODES.map((mode) => (
+            <option key={mode.value} value={mode.value}>
+              {mode.label}
+            </option>
+          ))}
+        </select>
+        <ChevronDown size={10} color={colors.textSecondary} style={chevronStyle} />
+      </div>
+    </div>
+  );
+}
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  height: 28,
+  padding: "0 8px",
+  flexShrink: 0,
+};
+
+const labelStyle: React.CSSProperties = {
+  color: colors.textSecondary,
+  fontFamily: fonts.ui,
+  fontSize: 9,
+  fontWeight: 600,
+  userSelect: "none",
+  flexShrink: 0,
+};
+
+const selectWrapperStyle: React.CSSProperties = {
+  position: "relative",
+  flex: 1,
+  minWidth: 0,
+};
+
+const selectStyle: React.CSSProperties = {
+  width: "100%",
+  height: 22,
+  background: colors.inputField,
+  color: colors.textTitle,
+  fontFamily: fonts.ui,
+  fontSize: fontSizes.xs,
+  border: "none",
+  borderRadius: 4,
+  padding: "0 20px 0 6px",
+  cursor: "pointer",
+  appearance: "none",
+  outline: "none",
+};
+
+const chevronStyle: React.CSSProperties = {
+  position: "absolute",
+  right: 6,
+  top: "50%",
+  transform: "translateY(-50%)",
+  pointerEvents: "none",
+};

--- a/src/components/layers/LayerRow.test.tsx
+++ b/src/components/layers/LayerRow.test.tsx
@@ -1,0 +1,249 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Translate: { toString: () => undefined } },
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+import type { LayerInfoDto } from "../../api/commands";
+import { useEditorStore } from "../../store/editorStore";
+
+const mockedInvoke = vi.mocked(invoke);
+
+function makeLayer(overrides: Partial<LayerInfoDto> = {}): LayerInfoDto {
+  return {
+    id: "layer1",
+    name: "Background",
+    opacity: 1.0,
+    blendMode: "normal",
+    visible: true,
+    locked: false,
+    thumbnail: [],
+    ...overrides,
+  };
+}
+
+const emptyReturnState = {
+  texture: null,
+  layers: [],
+  activeLayerId: null,
+  canUndo: false,
+  canRedo: false,
+};
+
+async function renderRow(
+  layer: LayerInfoDto,
+  opts: { isActive?: boolean; onSelect?: (id: string) => void } = {},
+) {
+  const { LayerRow } = await import("./LayerRow");
+  return render(
+    <LayerRow
+      layer={layer}
+      textureWidth={16}
+      textureHeight={16}
+      isActive={opts.isActive ?? false}
+      onSelect={opts.onSelect ?? vi.fn()}
+    />,
+  );
+}
+
+beforeEach(() => {
+  useEditorStore.setState({
+    texture: null,
+    layers: [],
+    activeLayerId: null,
+    canUndo: false,
+    canRedo: false,
+  });
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe("LayerRow", () => {
+  it("renders layer name and opacity", async () => {
+    await renderRow(makeLayer({ name: "Details", opacity: 0.75 }));
+    expect(screen.getByText("Details")).toBeDefined();
+    expect(screen.getByText("75%")).toBeDefined();
+  });
+
+  it("renders 100% for full opacity", async () => {
+    await renderRow(makeLayer({ opacity: 1.0 }));
+    expect(screen.getByText("100%")).toBeDefined();
+  });
+
+  it("calls onSelect when row is clicked", async () => {
+    const onSelect = vi.fn();
+    await renderRow(makeLayer({ id: "abc" }), { onSelect });
+    fireEvent.click(screen.getByText("Background"));
+    expect(onSelect).toHaveBeenCalledWith("abc");
+  });
+
+  // US3: Visibility toggle
+  it("toggles visibility when eye icon is clicked", async () => {
+    mockedInvoke.mockResolvedValueOnce(emptyReturnState);
+    await renderRow(makeLayer({ id: "x", visible: true }));
+
+    const svgs = document.querySelectorAll("svg");
+    expect(svgs.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      fireEvent.click(svgs[0]);
+    });
+
+    expect(mockedInvoke).toHaveBeenCalledWith("set_layer_visibility", {
+      layerId: "x",
+      visible: false,
+    });
+  });
+
+  // US5-AS1: Double-click rename
+  it("enters rename mode on double-click", async () => {
+    await renderRow(makeLayer({ name: "MyLayer" }));
+    const nameSpan = screen.getByText("MyLayer");
+    fireEvent.doubleClick(nameSpan);
+    const input = screen.getByDisplayValue("MyLayer") as HTMLInputElement;
+    expect(input).toBeDefined();
+  });
+
+  // US5-AS2: F2 rename
+  it("enters rename mode on F2 when active", async () => {
+    const { container } = await renderRow(makeLayer({ name: "TestLayer" }), {
+      isActive: true,
+    });
+    const row = container.firstElementChild as HTMLElement;
+    fireEvent.keyDown(row, { key: "F2" });
+    const input = screen.getByDisplayValue("TestLayer") as HTMLInputElement;
+    expect(input).toBeDefined();
+  });
+
+  it("does not enter rename mode on F2 when inactive", async () => {
+    const { container } = await renderRow(makeLayer({ name: "TestLayer" }), {
+      isActive: false,
+    });
+    const row = container.firstElementChild as HTMLElement;
+    fireEvent.keyDown(row, { key: "F2" });
+    expect(screen.queryByDisplayValue("TestLayer")).toBeNull();
+    expect(screen.getByText("TestLayer")).toBeDefined();
+  });
+
+  // US5-AS3: Enter confirms
+  it("confirms rename on Enter", async () => {
+    mockedInvoke.mockResolvedValueOnce(emptyReturnState);
+    await renderRow(makeLayer({ id: "r1", name: "Old" }));
+    fireEvent.doubleClick(screen.getByText("Old"));
+    const input = screen.getByDisplayValue("Old");
+    fireEvent.change(input, { target: { value: "New" } });
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+
+    expect(mockedInvoke).toHaveBeenCalledWith("set_layer_name", {
+      layerId: "r1",
+      name: "New",
+    });
+  });
+
+  // US5-AS4: Escape cancels
+  it("cancels rename on Escape", async () => {
+    await renderRow(makeLayer({ name: "Keep" }));
+    fireEvent.doubleClick(screen.getByText("Keep"));
+    const input = screen.getByDisplayValue("Keep");
+    fireEvent.change(input, { target: { value: "Changed" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(screen.queryByDisplayValue("Changed")).toBeNull();
+    expect(screen.getByText("Keep")).toBeDefined();
+  });
+
+  // US5-AS5: Blur confirms
+  it("confirms rename on blur", async () => {
+    mockedInvoke.mockResolvedValueOnce(emptyReturnState);
+    await renderRow(makeLayer({ id: "r2", name: "Original" }));
+    fireEvent.doubleClick(screen.getByText("Original"));
+    const input = screen.getByDisplayValue("Original");
+    fireEvent.change(input, { target: { value: "Blurred" } });
+
+    await act(async () => {
+      fireEvent.blur(input);
+    });
+
+    expect(mockedInvoke).toHaveBeenCalledWith("set_layer_name", {
+      layerId: "r2",
+      name: "Blurred",
+    });
+  });
+
+  // Edge case: empty name rejected
+  it("rejects empty name on rename", async () => {
+    await renderRow(makeLayer({ id: "r3", name: "Valid" }));
+    fireEvent.doubleClick(screen.getByText("Valid"));
+    const input = screen.getByDisplayValue("Valid");
+    fireEvent.change(input, { target: { value: "   " } });
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+
+    expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+
+  // Edge case: same name is a no-op
+  it("does not invoke setLayerName when name unchanged", async () => {
+    await renderRow(makeLayer({ id: "r4", name: "Same" }));
+    fireEvent.doubleClick(screen.getByText("Same"));
+    const input = screen.getByDisplayValue("Same");
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+
+    expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+
+  // Dimmed row for hidden layers
+  it("shows dimmed opacity for hidden layers", async () => {
+    const { container } = await renderRow(makeLayer({ visible: false }));
+    const row = container.firstElementChild as HTMLElement;
+    expect(row.style.opacity).toBe("0.4");
+  });
+
+  // Error handling
+  it("logs error when visibility toggle fails", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockedInvoke.mockRejectedValueOnce(new Error("fail"));
+    await renderRow(makeLayer({ id: "err", visible: true }));
+
+    const svgs = document.querySelectorAll("svg");
+    await act(async () => {
+      fireEvent.click(svgs[0]);
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[LayerRow] setLayerVisibility failed:",
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/components/layers/LayerRow.tsx
+++ b/src/components/layers/LayerRow.tsx
@@ -1,0 +1,311 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Eye, EyeOff } from "lucide-react";
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from "react";
+import type { LayerInfoDto } from "../../api/commands";
+import { setLayerName, setLayerVisibility } from "../../api/commands";
+import { useEditorStore } from "../../store/editorStore";
+import { colors, fontSizes, fonts } from "../../styles/theme";
+
+// --- Presentational component (used by both sortable row and DragOverlay) ---
+
+interface LayerRowContentProps {
+  layer: LayerInfoDto;
+  textureWidth: number;
+  textureHeight: number;
+  isActive: boolean;
+  isDragOverlay?: boolean;
+}
+
+export function LayerRowContent({
+  layer,
+  textureWidth,
+  textureHeight,
+  isActive,
+  isDragOverlay,
+}: LayerRowContentProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const thumbnailData = useMemo(
+    () => (layer.thumbnail.length > 0 ? new Uint8ClampedArray(layer.thumbnail) : null),
+    [layer.thumbnail],
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || textureWidth === 0 || textureHeight === 0 || !thumbnailData) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const imageData = new ImageData(thumbnailData, textureWidth, textureHeight);
+    createImageBitmap(imageData)
+      .then((bitmap) => {
+        ctx.clearRect(0, 0, 18, 18);
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(bitmap, 0, 0, 18, 18);
+        bitmap.close();
+      })
+      .catch((err) => console.warn("[LayerRow] thumbnail render failed:", err));
+  }, [thumbnailData, textureWidth, textureHeight]);
+
+  const opacityPercent = `${Math.round(layer.opacity * 100)}%`;
+  const VisibilityIcon = layer.visible ? Eye : EyeOff;
+  const iconColor = layer.visible ? colors.accent : colors.textSecondary;
+
+  const style: CSSProperties = {
+    ...rowStyle,
+    backgroundColor: isActive ? colors.selectedItem : "transparent",
+    opacity: layer.visible ? 1 : 0.4,
+    ...(isDragOverlay && {
+      boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
+      cursor: "grabbing",
+    }),
+  };
+
+  return (
+    <div style={style}>
+      <div style={visibilityButtonStyle}>
+        <VisibilityIcon size={12} color={iconColor} />
+      </div>
+      <canvas ref={canvasRef} width={18} height={18} style={thumbnailStyle} />
+      <span style={nameStyle}>{layer.name}</span>
+      <span style={opacityStyle}>{opacityPercent}</span>
+    </div>
+  );
+}
+
+// --- Sortable wrapper (used in the list) ---
+
+interface LayerRowProps {
+  layer: LayerInfoDto;
+  textureWidth: number;
+  textureHeight: number;
+  isActive: boolean;
+  onSelect: (id: string) => void;
+}
+
+export function LayerRow({
+  layer,
+  textureWidth,
+  textureHeight,
+  isActive,
+  onSelect,
+}: LayerRowProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
+  const isSubmitting = useRef(false);
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: layer.id });
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const thumbnailData = useMemo(
+    () => (layer.thumbnail.length > 0 ? new Uint8ClampedArray(layer.thumbnail) : null),
+    [layer.thumbnail],
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || textureWidth === 0 || textureHeight === 0 || !thumbnailData) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const imageData = new ImageData(thumbnailData, textureWidth, textureHeight);
+    createImageBitmap(imageData)
+      .then((bitmap) => {
+        ctx.clearRect(0, 0, 18, 18);
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(bitmap, 0, 0, 18, 18);
+        bitmap.close();
+      })
+      .catch((err) => console.warn("[LayerRow] thumbnail render failed:", err));
+  }, [thumbnailData, textureWidth, textureHeight]);
+
+  useEffect(() => {
+    if (isRenaming && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isRenaming]);
+
+  const opacityPercent = `${Math.round(layer.opacity * 100)}%`;
+
+  const handleToggleVisibility = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      const state = await setLayerVisibility(layer.id, !layer.visible);
+      useEditorStore.setState(state);
+    } catch (err) {
+      console.error("[LayerRow] setLayerVisibility failed:", err);
+    }
+  };
+
+  const startRename = () => {
+    setRenameValue(layer.name);
+    setIsRenaming(true);
+  };
+
+  const confirmRename = async () => {
+    if (isSubmitting.current) return;
+    isSubmitting.current = true;
+    setIsRenaming(false);
+    try {
+      const trimmed = renameValue.trim();
+      if (trimmed.length === 0 || trimmed === layer.name) return;
+      const state = await setLayerName(layer.id, trimmed);
+      useEditorStore.setState(state);
+    } catch (err) {
+      console.error("[LayerRow] setLayerName failed:", err);
+    } finally {
+      isSubmitting.current = false;
+    }
+  };
+
+  const cancelRename = () => {
+    setIsRenaming(false);
+  };
+
+  const handleRenameKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      confirmRename();
+    } else if (e.key === "Escape") {
+      cancelRename();
+    }
+  };
+
+  const handleRowKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "F2" && isActive && !isRenaming) {
+      e.preventDefault();
+      startRename();
+    }
+  };
+
+  const VisibilityIcon = layer.visible ? Eye : EyeOff;
+  const iconColor = layer.visible ? colors.accent : colors.textSecondary;
+
+  const style: CSSProperties = {
+    ...rowStyle,
+    backgroundColor: isActive ? colors.selectedItem : "transparent",
+    opacity: isDragging ? 0.4 : layer.visible ? 1 : 0.4,
+    transform: CSS.Translate.toString(transform),
+    transition: transition ?? undefined,
+  };
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: dnd-kit manages keyboard interaction via listeners/attributes spread
+    <div
+      ref={setNodeRef}
+      style={style}
+      onClick={() => onSelect(layer.id)}
+      onKeyDown={handleRowKeyDown}
+      {...attributes}
+      {...listeners}
+    >
+      <button
+        type="button"
+        style={visibilityButtonStyle}
+        onClick={handleToggleVisibility}
+      >
+        <VisibilityIcon size={12} color={iconColor} />
+      </button>
+      <canvas ref={canvasRef} width={18} height={18} style={thumbnailStyle} />
+      {isRenaming ? (
+        <input
+          ref={inputRef}
+          style={renameInputStyle}
+          value={renameValue}
+          onChange={(e) => setRenameValue(e.target.value)}
+          onKeyDown={handleRenameKeyDown}
+          onBlur={confirmRename}
+          onClick={(e) => e.stopPropagation()}
+        />
+      ) : (
+        // biome-ignore lint/a11y/useSemanticElements: inline rename activator, not a true textbox
+        <span
+          role="textbox"
+          tabIndex={-1}
+          style={nameStyle}
+          onDoubleClick={(e) => {
+            e.stopPropagation();
+            startRename();
+          }}
+        >
+          {layer.name}
+        </span>
+      )}
+      <span style={opacityStyle}>{opacityPercent}</span>
+    </div>
+  );
+}
+
+// --- Styles ---
+
+const rowStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  height: 30,
+  borderRadius: 4,
+  padding: "0 6px",
+  cursor: "pointer",
+  flexShrink: 0,
+};
+
+const visibilityButtonStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 20,
+  height: 20,
+  flexShrink: 0,
+  cursor: "pointer",
+  borderRadius: 3,
+  background: "transparent",
+  border: "none",
+  padding: 0,
+};
+
+const thumbnailStyle: CSSProperties = {
+  width: 18,
+  height: 18,
+  borderRadius: 3,
+  flexShrink: 0,
+  imageRendering: "pixelated",
+};
+
+const nameStyle: CSSProperties = {
+  color: colors.textPrimary,
+  fontFamily: fonts.ui,
+  fontSize: fontSizes.xs,
+  fontWeight: "normal",
+  flex: 1,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  userSelect: "none",
+};
+
+const renameInputStyle: CSSProperties = {
+  color: colors.textPrimary,
+  fontFamily: fonts.ui,
+  fontSize: fontSizes.xs,
+  fontWeight: "normal",
+  flex: 1,
+  background: colors.inputField,
+  border: `1px solid ${colors.accent}`,
+  borderRadius: 2,
+  padding: "1px 3px",
+  outline: "none",
+  minWidth: 0,
+};
+
+const opacityStyle: CSSProperties = {
+  color: colors.textSecondary,
+  fontFamily: fonts.mono,
+  fontSize: 8,
+  fontWeight: "normal",
+  flexShrink: 0,
+  userSelect: "none",
+};

--- a/src/components/layers/LayersPanel.test.tsx
+++ b/src/components/layers/LayersPanel.test.tsx
@@ -1,0 +1,254 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+// Mock @dnd-kit — render children without drag behavior
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DragOverlay: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  closestCenter: vi.fn(),
+  defaultDropAnimationSideEffects: vi.fn(() => ({})),
+  PointerSensor: vi.fn(),
+  useSensor: vi.fn(),
+  useSensors: vi.fn(() => []),
+}));
+
+vi.mock("@dnd-kit/modifiers", () => ({
+  restrictToVerticalAxis: vi.fn(),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: vi.fn(),
+  arrayMove: vi.fn((arr: unknown[], from: number, to: number) => {
+    const copy = [...arr];
+    const [item] = copy.splice(from, 1);
+    copy.splice(to, 0, item);
+    return copy;
+  }),
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+import type { EditorStateDto, LayerInfoDto } from "../../api/commands";
+import { useEditorStore } from "../../store/editorStore";
+
+const mockedInvoke = vi.mocked(invoke);
+
+function makeLayer(
+  id: string,
+  name: string,
+  overrides?: Partial<LayerInfoDto>,
+): LayerInfoDto {
+  return {
+    id,
+    name,
+    opacity: 1.0,
+    blendMode: "normal",
+    visible: true,
+    locked: false,
+    thumbnail: [],
+    ...overrides,
+  };
+}
+
+function makeReturnState(
+  layers: LayerInfoDto[],
+  activeLayerId: string | null,
+): EditorStateDto {
+  return {
+    texture: { namespace: "mc", path: "stone", width: 16, height: 16, dirty: true },
+    layers,
+    activeLayerId,
+    canUndo: true,
+    canRedo: false,
+  };
+}
+
+function setStoreState(layers: LayerInfoDto[], activeLayerId: string | null) {
+  useEditorStore.setState({
+    texture: { namespace: "mc", path: "stone", width: 16, height: 16, dirty: false },
+    layers,
+    activeLayerId,
+    canUndo: false,
+    canRedo: false,
+  });
+}
+
+async function importAndRender() {
+  const { LayersPanel } = await import("./LayersPanel");
+  return render(<LayersPanel />);
+}
+
+beforeEach(() => {
+  useEditorStore.setState({
+    texture: null,
+    layers: [],
+    activeLayerId: null,
+    canUndo: false,
+    canRedo: false,
+  });
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe("LayersPanel", () => {
+  it("shows empty state when no texture is open", async () => {
+    await importAndRender();
+    expect(screen.getByText("No texture open")).toBeDefined();
+  });
+
+  it("renders layer rows in reverse order (topmost first)", async () => {
+    const layers = [
+      makeLayer("a", "Bottom"),
+      makeLayer("b", "Middle"),
+      makeLayer("c", "Top"),
+    ];
+    setStoreState(layers, "b");
+
+    await importAndRender();
+
+    const names = screen.getAllByText(/Bottom|Middle|Top/);
+    expect(names[0].textContent).toBe("Top");
+    expect(names[1].textContent).toBe("Middle");
+    expect(names[2].textContent).toBe("Bottom");
+  });
+
+  it("renders action buttons when texture is open", async () => {
+    setStoreState([makeLayer("a", "Base")], "a");
+    await importAndRender();
+    expect(screen.getByTitle("Add layer")).toBeDefined();
+    expect(screen.getByTitle(/[Dd]elete/)).toBeDefined();
+    expect(screen.getByTitle("Duplicate layer")).toBeDefined();
+  });
+
+  it("disables delete button when only one layer", async () => {
+    setStoreState([makeLayer("a", "Only")], "a");
+    await importAndRender();
+    const btn = screen.getByTitle("Cannot delete the last layer") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("enables delete button when multiple layers exist", async () => {
+    setStoreState([makeLayer("a", "A"), makeLayer("b", "B")], "a");
+    await importAndRender();
+    const btn = screen.getByTitle("Delete layer") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+
+  // US2: Add
+  it("calls addLayer when add button is clicked", async () => {
+    mockedInvoke.mockResolvedValueOnce(
+      makeReturnState([makeLayer("a", "Base"), makeLayer("b", "Layer 1")], "b"),
+    );
+    setStoreState([makeLayer("a", "Base")], "a");
+    await importAndRender();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTitle("Add layer"));
+    });
+
+    expect(mockedInvoke).toHaveBeenCalledWith(
+      "add_layer",
+      expect.objectContaining({ name: expect.any(String) }),
+    );
+  });
+
+  // US2: Delete
+  it("calls removeLayer when delete button is clicked with multiple layers", async () => {
+    mockedInvoke.mockResolvedValueOnce(makeReturnState([makeLayer("b", "B")], "b"));
+    setStoreState([makeLayer("a", "A"), makeLayer("b", "B")], "a");
+    await importAndRender();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTitle("Delete layer"));
+    });
+
+    expect(mockedInvoke).toHaveBeenCalledWith("remove_layer", { layerId: "a" });
+  });
+
+  // US2: Duplicate
+  it("calls duplicateLayer when duplicate button is clicked", async () => {
+    mockedInvoke.mockResolvedValueOnce(
+      makeReturnState([makeLayer("a", "Base"), makeLayer("b", "Base (copy)")], "b"),
+    );
+    setStoreState([makeLayer("a", "Base")], "a");
+    await importAndRender();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTitle("Duplicate layer"));
+    });
+
+    expect(mockedInvoke).toHaveBeenCalledWith("duplicate_layer", { layerId: "a" });
+  });
+
+  // US1: Select layer
+  it("selecting a layer updates activeLayerId in store", async () => {
+    setStoreState([makeLayer("a", "Bottom"), makeLayer("b", "Top")], "a");
+    await importAndRender();
+
+    fireEvent.click(screen.getByText("Top"));
+
+    expect(useEditorStore.getState().activeLayerId).toBe("b");
+  });
+
+  // US6: Blend mode change
+  it("calls setLayerBlendMode when blend mode is changed", async () => {
+    mockedInvoke.mockResolvedValueOnce(
+      makeReturnState([makeLayer("a", "Base", { blendMode: "multiply" })], "a"),
+    );
+    setStoreState([makeLayer("a", "Base")], "a");
+    await importAndRender();
+
+    const select = screen.getByRole("combobox");
+    await act(async () => {
+      fireEvent.change(select, { target: { value: "multiply" } });
+    });
+
+    expect(mockedInvoke).toHaveBeenCalledWith("set_layer_blend_mode", {
+      layerId: "a",
+      blendMode: "multiply",
+    });
+  });
+
+  // US6: Blend mode reflects active layer
+  it("renders blend mode selector for active layer", async () => {
+    setStoreState([makeLayer("a", "Base", { blendMode: "screen" })], "a");
+    await importAndRender();
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(select.value).toBe("screen");
+  });
+
+  // Error handling
+  it("logs error when addLayer fails", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockedInvoke.mockRejectedValueOnce(new Error("IPC failed"));
+    setStoreState([makeLayer("a", "Base")], "a");
+    await importAndRender();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTitle("Add layer"));
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[LayersPanel] addLayer failed:",
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/components/layers/LayersPanel.tsx
+++ b/src/components/layers/LayersPanel.tsx
@@ -1,0 +1,304 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  DragOverlay,
+  type DragStartEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import {
+  arrayMove,
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { Copy, Plus, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { BlendMode, LayerInfoDto } from "../../api/commands";
+import {
+  addLayer,
+  duplicateLayer,
+  moveLayer,
+  removeLayer,
+  setLayerBlendMode,
+} from "../../api/commands";
+import { useEditorStore } from "../../store/editorStore";
+import { colors, fontSizes, fonts } from "../../styles/theme";
+import { BlendModeSelect } from "./BlendModeSelect";
+import { LayerRow, LayerRowContent } from "./LayerRow";
+
+/** Monotonic counter for unique default layer names across additions/deletions. */
+let layerNameCounter = 0;
+
+export function LayersPanel() {
+  const layers = useEditorStore((s) => s.layers);
+  const activeLayerId = useEditorStore((s) => s.activeLayerId);
+  const texture = useEditorStore((s) => s.texture);
+  const [draggedLayer, setDraggedLayer] = useState<LayerInfoDto | null>(null);
+  const isPending = useRef(false);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Delete" && !e.repeat) {
+        // Don't trigger if user is typing in an input (e.g. rename)
+        const tag = (e.target as HTMLElement).tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA") return;
+        handleRemoveLayer();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+
+  // Intentional frontend-only state: active layer selection is latency-sensitive
+  // and does not require a backend round-trip. The backend's active_layer_id is
+  // synchronized on every mutation command response and state-changed event.
+  const setActiveLayer = (id: string) => {
+    useEditorStore.setState({ activeLayerId: id });
+  };
+
+  const textureWidth = texture?.width ?? 0;
+  const textureHeight = texture?.height ?? 0;
+  const hasTexture = texture !== null;
+
+  // Reverse layers for display (topmost first)
+  const displayLayers = [...layers].reverse();
+  const sortableIds = displayLayers.map((l) => l.id);
+
+  const handleAddLayer = async () => {
+    if (!hasTexture || isPending.current) return;
+    isPending.current = true;
+    try {
+      layerNameCounter++;
+      const state = await addLayer(`Layer ${layerNameCounter}`);
+      useEditorStore.setState(state);
+    } catch (err) {
+      console.error("[LayersPanel] addLayer failed:", err);
+    } finally {
+      isPending.current = false;
+    }
+  };
+
+  const handleRemoveLayer = async () => {
+    if (!activeLayerId || layers.length <= 1 || isPending.current) return;
+    isPending.current = true;
+    try {
+      const state = await removeLayer(activeLayerId);
+      useEditorStore.setState(state);
+    } catch (err) {
+      console.error("[LayersPanel] removeLayer failed:", err);
+    } finally {
+      isPending.current = false;
+    }
+  };
+
+  const handleDuplicateLayer = async () => {
+    if (!activeLayerId || isPending.current) return;
+    isPending.current = true;
+    try {
+      const state = await duplicateLayer(activeLayerId);
+      useEditorStore.setState(state);
+    } catch (err) {
+      console.error("[LayersPanel] duplicateLayer failed:", err);
+    } finally {
+      isPending.current = false;
+    }
+  };
+
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      const layer = displayLayers.find((l) => l.id === event.active.id);
+      setDraggedLayer(layer ?? null);
+    },
+    [displayLayers],
+  );
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    setDraggedLayer(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const visualFromIndex = displayLayers.findIndex((l) => l.id === active.id);
+    const visualToIndex = displayLayers.findIndex((l) => l.id === over.id);
+    if (visualFromIndex === -1 || visualToIndex === -1) return;
+
+    // Optimistic update: reorder locally before the backend responds
+    const reordered = arrayMove(displayLayers, visualFromIndex, visualToIndex);
+    useEditorStore.setState({ layers: [...reordered].reverse() });
+
+    // Convert visual indices (0=top) to backend indices (0=bottom)
+    const len = layers.length;
+    const backendFrom = len - 1 - visualFromIndex;
+    const backendTo = len - 1 - visualToIndex;
+
+    try {
+      const state = await moveLayer(backendFrom, backendTo);
+      useEditorStore.setState(state);
+    } catch (err) {
+      console.error("[LayersPanel] moveLayer failed:", err);
+      useEditorStore.getState().refreshState();
+    }
+  };
+
+  const handleDragCancel = useCallback(() => {
+    setDraggedLayer(null);
+  }, []);
+
+  const activeLayer = layers.find((l) => l.id === activeLayerId);
+
+  const handleBlendModeChange = async (mode: BlendMode) => {
+    if (!activeLayerId || isPending.current) return;
+    isPending.current = true;
+    try {
+      const state = await setLayerBlendMode(activeLayerId, mode);
+      useEditorStore.setState(state);
+    } catch (err) {
+      console.error("[LayersPanel] setLayerBlendMode failed:", err);
+    } finally {
+      isPending.current = false;
+    }
+  };
+
+  return (
+    <div style={containerStyle}>
+      {/* Layer list */}
+      <div style={listStyle}>
+        {!hasTexture ? (
+          <span style={emptyStyle}>No texture open</span>
+        ) : (
+          <DndContext
+            sensors={sensors}
+            modifiers={[restrictToVerticalAxis]}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+          >
+            <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+              {displayLayers.map((layer) => (
+                <LayerRow
+                  key={layer.id}
+                  layer={layer}
+                  textureWidth={textureWidth}
+                  textureHeight={textureHeight}
+                  isActive={layer.id === activeLayerId}
+                  onSelect={setActiveLayer}
+                />
+              ))}
+            </SortableContext>
+            {createPortal(
+              <DragOverlay dropAnimation={null}>
+                {draggedLayer ? (
+                  <LayerRowContent
+                    layer={draggedLayer}
+                    textureWidth={textureWidth}
+                    textureHeight={textureHeight}
+                    isActive
+                    isDragOverlay
+                  />
+                ) : null}
+              </DragOverlay>,
+              document.body,
+            )}
+          </DndContext>
+        )}
+      </div>
+
+      {/* Blend mode */}
+      {hasTexture && activeLayer && (
+        <BlendModeSelect value={activeLayer.blendMode} onChange={handleBlendModeChange} />
+      )}
+
+      {/* Action bar */}
+      {hasTexture && (
+        <div style={actionBarStyle}>
+          <button
+            type="button"
+            style={actionButtonStyle}
+            onClick={handleAddLayer}
+            title="Add layer"
+          >
+            <Plus size={12} color={colors.textSecondary} />
+          </button>
+          <button
+            type="button"
+            style={{
+              ...actionButtonStyle,
+              opacity: layers.length <= 1 ? 0.4 : 1,
+              cursor: layers.length <= 1 ? "not-allowed" : "pointer",
+            }}
+            onClick={handleRemoveLayer}
+            disabled={layers.length <= 1}
+            title={layers.length <= 1 ? "Cannot delete the last layer" : "Delete layer"}
+          >
+            <Trash2 size={12} color={colors.textSecondary} />
+          </button>
+          <button
+            type="button"
+            style={actionButtonStyle}
+            onClick={handleDuplicateLayer}
+            title="Duplicate layer"
+          >
+            <Copy size={12} color={colors.textSecondary} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const containerStyle: React.CSSProperties = {
+  width: "100%",
+  height: "100%",
+  display: "flex",
+  flexDirection: "column",
+  background: colors.panelBody,
+  overflow: "hidden",
+};
+
+const listStyle: React.CSSProperties = {
+  flex: 1,
+  overflowY: "auto",
+  padding: 4,
+  display: "flex",
+  flexDirection: "column",
+  gap: 2,
+};
+
+const emptyStyle: React.CSSProperties = {
+  color: colors.textMuted,
+  fontFamily: fonts.ui,
+  fontSize: fontSizes.sm,
+  textAlign: "center",
+  marginTop: 16,
+  userSelect: "none",
+};
+
+const actionBarStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 4,
+  height: 28,
+  padding: "0 6px",
+  flexShrink: 0,
+};
+
+const actionButtonStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 24,
+  height: 22,
+  borderRadius: 4,
+  background: colors.inputField,
+  border: "none",
+  cursor: "pointer",
+  padding: 0,
+};

--- a/src/components/panels/LayersPanel.tsx
+++ b/src/components/panels/LayersPanel.tsx
@@ -1,25 +1,6 @@
 import type { IDockviewPanelProps } from "dockview";
-import { fontSizes } from "../../styles/theme";
+import { LayersPanel as LayersPanelContent } from "../layers/LayersPanel";
 
 export function LayersPanel(_props: IDockviewPanelProps) {
-  return (
-    <div style={containerStyle}>
-      <span style={placeholderStyle}>Layers</span>
-    </div>
-  );
+  return <LayersPanelContent />;
 }
-
-const containerStyle: React.CSSProperties = {
-  width: "100%",
-  height: "100%",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  background: "#252525",
-};
-
-const placeholderStyle: React.CSSProperties = {
-  color: "#666666",
-  fontSize: fontSizes.lg,
-  userSelect: "none",
-};

--- a/src/store/editorStore.test.ts
+++ b/src/store/editorStore.test.ts
@@ -53,6 +53,7 @@ describe("editorStore", () => {
           blendMode: "normal",
           visible: true,
           locked: false,
+          thumbnail: [],
         },
       ],
       activeLayerId: "abc123",
@@ -89,6 +90,48 @@ describe("editorStore", () => {
     expect(state.texture).toBeNull();
     expect(state.layers).toEqual([]);
     expect(state.activeLayerId).toBeNull();
+  });
+
+  it("refreshState defaults activeLayerId to topmost layer when null", async () => {
+    const stateWithoutActive: EditorStateDto = {
+      texture: {
+        namespace: "minecraft",
+        path: "block/stone",
+        width: 16,
+        height: 16,
+        dirty: false,
+      },
+      layers: [
+        {
+          id: "bottom",
+          name: "Bottom",
+          opacity: 1.0,
+          blendMode: "normal",
+          visible: true,
+          locked: false,
+          thumbnail: [],
+        },
+        {
+          id: "top",
+          name: "Top",
+          opacity: 1.0,
+          blendMode: "normal",
+          visible: true,
+          locked: false,
+          thumbnail: [],
+        },
+      ],
+      activeLayerId: null,
+      canUndo: false,
+      canRedo: false,
+    };
+
+    mockedInvoke.mockResolvedValueOnce(stateWithoutActive);
+
+    await useEditorStore.getState().refreshState();
+
+    // Should default to topmost layer (last in array = bottom-to-top order)
+    expect(useEditorStore.getState().activeLayerId).toBe("top");
   });
 
   it("refreshState handles errors gracefully", async () => {

--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -17,6 +17,10 @@ export const useEditorStore = create<EditorStore>((set) => ({
   refreshState: async () => {
     try {
       const state = await getEditorState();
+      // Default to topmost layer if no active layer is set (US1-AS3)
+      if (!state.activeLayerId && state.layers.length > 0) {
+        state.activeLayerId = state.layers[state.layers.length - 1].id;
+      }
       set(state);
     } catch (err) {
       console.error("[editorStore] failed to refresh state:", err);

--- a/ui-design
+++ b/ui-design
@@ -229,7 +229,7 @@
               "reusable": true,
               "clip": true,
               "width": 260,
-              "height": 180,
+              "height": 210,
               "fill": "#252525",
               "cornerRadius": 6,
               "layout": "vertical",
@@ -388,6 +388,69 @@
                           "fontFamily": "Geist Mono",
                           "fontSize": 8,
                           "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "uYVM5",
+                  "name": "plBlend",
+                  "width": "fill_container",
+                  "height": 28,
+                  "gap": 6,
+                  "padding": [
+                    0,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "r33y5",
+                      "name": "blendLabel",
+                      "fill": "#888888",
+                      "content": "Blend",
+                      "fontFamily": "Inter",
+                      "fontSize": 9,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "H48Kv",
+                      "name": "plBlendDrop",
+                      "width": "fill_container",
+                      "height": 22,
+                      "fill": "#333333",
+                      "cornerRadius": 4,
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        6
+                      ],
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Zvwj9",
+                          "name": "blendValue",
+                          "fill": "#CCCCCC",
+                          "content": "Normal",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "SF5Bm",
+                          "name": "blendChevron",
+                          "width": 10,
+                          "height": 10,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#888888"
                         }
                       ]
                     }
@@ -675,9 +738,48 @@
                       "id": "PVMNE",
                       "name": "pcHex",
                       "width": "fill_container",
-                      "gap": 6,
+                      "height": 24,
+                      "gap": 5,
                       "alignItems": "center",
                       "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 3,
+                          "id": "OuUBH",
+                          "name": "pcFg",
+                          "fill": "#000000",
+                          "width": 20,
+                          "height": 20,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1.5,
+                            "fill": "#4A9FD8"
+                          }
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "MAkG6",
+                          "name": "pcSwap",
+                          "width": 10,
+                          "height": 10,
+                          "iconFontName": "arrow-left-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "#666666"
+                        },
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 3,
+                          "id": "ePXEo",
+                          "name": "pcBg",
+                          "fill": "#FFFFFF",
+                          "width": 20,
+                          "height": 20,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#444444"
+                          }
+                        },
                         {
                           "type": "text",
                           "id": "5il2T",
@@ -713,15 +815,6 @@
                               "fontWeight": "normal"
                             }
                           ]
-                        },
-                        {
-                          "type": "rectangle",
-                          "cornerRadius": 4,
-                          "id": "wHvjZ",
-                          "name": "color-preview",
-                          "fill": "#4A9FD8",
-                          "width": 20,
-                          "height": 20
                         }
                       ]
                     }
@@ -3923,9 +4016,26 @@
                       "x": 78,
                       "y": 10
                     },
+                    "uYVM5": {
+                      "width": "fill_container",
+                      "y": 154
+                    },
+                    "r33y5": {
+                      "x": 8,
+                      "y": 8.5
+                    },
+                    "H48Kv": {
+                      "width": "fill_container",
+                      "x": 39,
+                      "y": 3
+                    },
+                    "Zvwj9": {
+                      "x": 6,
+                      "y": 5
+                    },
                     "fs63K": {
                       "width": "fill_container",
-                      "y": 152
+                      "y": 182
                     },
                     "QV4l3": {
                       "x": 6,
@@ -3960,7 +4070,7 @@
                   "width": "fill_container",
                   "name": "rpColor",
                   "x": 4,
-                  "y": 188,
+                  "y": 218,
                   "descendants": {
                     "oXM4u": {
                       "width": "fill_container"
@@ -3989,19 +4099,29 @@
                       "x": 6,
                       "y": 102
                     },
-                    "5il2T": {
+                    "OuUBH": {
+                      "x": 0,
+                      "y": 0
+                    },
+                    "MAkG6": {
+                      "x": 25,
                       "y": 5
+                    },
+                    "ePXEo": {
+                      "x": 40
+                    },
+                    "5il2T": {
+                      "y": 5,
+                      "x": 65
                     },
                     "InUfn": {
                       "width": "fill_container",
-                      "x": 21
+                      "x": 85,
+                      "y": 0
                     },
                     "hMaCH": {
                       "x": 6,
                       "y": 4
-                    },
-                    "wHvjZ": {
-                      "x": 240
                     }
                   }
                 },
@@ -4012,7 +4132,7 @@
                   "width": "fill_container",
                   "name": "rpPalette",
                   "x": 4,
-                  "y": 372,
+                  "y": 402,
                   "descendants": {
                     "D8yi5": {
                       "width": "fill_container"
@@ -4111,7 +4231,7 @@
                   "height": "fill_container",
                   "name": "rpModel",
                   "x": 4,
-                  "y": 506,
+                  "y": 536,
                   "descendants": {
                     "CbkNq": {
                       "width": "fill_container"
@@ -4958,9 +5078,26 @@
                       "x": 78,
                       "y": 10
                     },
+                    "uYVM5": {
+                      "width": "fill_container",
+                      "y": 154
+                    },
+                    "r33y5": {
+                      "x": 8,
+                      "y": 8.5
+                    },
+                    "H48Kv": {
+                      "width": "fill_container",
+                      "x": 39,
+                      "y": 3
+                    },
+                    "Zvwj9": {
+                      "x": 6,
+                      "y": 5
+                    },
                     "fs63K": {
                       "width": "fill_container",
-                      "y": 152
+                      "y": 182
                     },
                     "QV4l3": {
                       "x": 6,
@@ -4995,7 +5132,7 @@
                   "width": "fill_container",
                   "name": "cmpPnlColor",
                   "x": 4,
-                  "y": 188,
+                  "y": 218,
                   "descendants": {
                     "oXM4u": {
                       "width": "fill_container"
@@ -5024,19 +5161,29 @@
                       "x": 6,
                       "y": 102
                     },
-                    "5il2T": {
+                    "OuUBH": {
+                      "x": 0,
+                      "y": 0
+                    },
+                    "MAkG6": {
+                      "x": 25,
                       "y": 5
+                    },
+                    "ePXEo": {
+                      "x": 40
+                    },
+                    "5il2T": {
+                      "y": 5,
+                      "x": 65
                     },
                     "InUfn": {
                       "width": "fill_container",
-                      "x": 21
+                      "x": 85,
+                      "y": 0
                     },
                     "hMaCH": {
                       "x": 6,
                       "y": 4
-                    },
-                    "wHvjZ": {
-                      "x": 240
                     }
                   }
                 },
@@ -5047,7 +5194,7 @@
                   "width": "fill_container",
                   "name": "cmpPnlPalette",
                   "x": 4,
-                  "y": 372,
+                  "y": 402,
                   "descendants": {
                     "D8yi5": {
                       "width": "fill_container"
@@ -5146,7 +5293,7 @@
                   "height": "fill_container",
                   "name": "cmpPnlModel",
                   "x": 4,
-                  "y": 506,
+                  "y": 536,
                   "descendants": {
                     "CbkNq": {
                       "width": "fill_container"
@@ -5593,9 +5740,26 @@
                       "x": 78,
                       "y": 10
                     },
+                    "uYVM5": {
+                      "width": "fill_container",
+                      "y": 154
+                    },
+                    "r33y5": {
+                      "x": 8,
+                      "y": 8.5
+                    },
+                    "H48Kv": {
+                      "width": "fill_container",
+                      "x": 39,
+                      "y": 3
+                    },
+                    "Zvwj9": {
+                      "x": 6,
+                      "y": 5
+                    },
                     "fs63K": {
                       "width": "fill_container",
-                      "y": 152
+                      "y": 182
                     },
                     "QV4l3": {
                       "x": 6,
@@ -5630,7 +5794,7 @@
                   "width": "fill_container",
                   "name": "esColor",
                   "x": 4,
-                  "y": 188,
+                  "y": 218,
                   "descendants": {
                     "oXM4u": {
                       "width": "fill_container"
@@ -5659,19 +5823,29 @@
                       "x": 6,
                       "y": 102
                     },
-                    "5il2T": {
+                    "OuUBH": {
+                      "x": 0,
+                      "y": 0
+                    },
+                    "MAkG6": {
+                      "x": 25,
                       "y": 5
+                    },
+                    "ePXEo": {
+                      "x": 40
+                    },
+                    "5il2T": {
+                      "y": 5,
+                      "x": 65
                     },
                     "InUfn": {
                       "width": "fill_container",
-                      "x": 21
+                      "x": 85,
+                      "y": 0
                     },
                     "hMaCH": {
                       "x": 6,
                       "y": 4
-                    },
-                    "wHvjZ": {
-                      "x": 240
                     }
                   }
                 },
@@ -5682,7 +5856,7 @@
                   "width": "fill_container",
                   "name": "esPalette",
                   "x": 4,
-                  "y": 372,
+                  "y": 402,
                   "descendants": {
                     "D8yi5": {
                       "width": "fill_container"
@@ -5781,7 +5955,7 @@
                   "height": "fill_container",
                   "name": "esModel",
                   "x": 4,
-                  "y": 506,
+                  "y": 536,
                   "descendants": {
                     "CbkNq": {
                       "width": "fill_container"


### PR DESCRIPTION
## Summary

- Add a fully interactive **Layers panel** for multi-layer texture editing: view, select, add, delete, duplicate, reorder, rename, toggle visibility, and change blend modes
- Backend extended with `duplicate_layer` command, insert-above-active, min-1-layer guard, and thumbnail data in DTOs
- Drag-and-drop reorder via @dnd-kit with optimistic state updates and `createPortal` overlay (fixes dockview offset)
- 30 new frontend component tests + 17 new Rust unit tests (264 Rust / 168 frontend total)

## Motivation

Closes #10

## What changed

```
src-tauri/src/
  domain/
    layer.rs             # + duplicate() method (unlocked copy)
    layer_stack.rs       # + insert_layer(), index_of()
  use_cases/
    editor_service.rs    # + add_layer_above(), duplicate_layer() with undo
  commands/
    dto.rs               # + thumbnail field on LayerInfoDto
    layer_commands.rs    # + duplicate_layer cmd, insert-above-active, last-layer guard
  error.rs               # + AppError::Validation variant
  lib.rs                 # register duplicate_layer

src/
  api/commands.ts        # + thumbnail type, duplicateLayer()
  components/
    layers/              # NEW feature module
      LayerRow.tsx       # Sortable row: thumbnail, visibility, rename, opacity
      LayersPanel.tsx    # Panel: DnD, blend mode, action bar, Delete shortcut
      BlendModeSelect.tsx # Normal/Multiply/Screen/Overlay dropdown
      *.test.tsx         # 30 component tests
    panels/
      LayersPanel.tsx    # Thin dockview wrapper (delegates to layers/)
  store/editorStore.ts   # Default active layer to topmost fallback

specs/010-layers-panel/  # Full speckit artifacts (spec, plan, tasks, research, contracts)
```

## Key decisions

| Decision | Why |
|----------|-----|
| `createPortal(DragOverlay, document.body)` | Dockview panels have CSS transforms that cause offset bugs with dnd-kit's fixed positioning |
| `dropAnimation={null}` + optimistic `arrayMove` | Async backend reorder causes bounce-back animation; optimistic update + no animation eliminates the glitch |
| `CSS.Translate.toString()` not `CSS.Transform.toString()` | Avoids scaleX/scaleY components that cause visual jumps on uniform-size items |
| `AppError::Validation` variant | Separates user-facing business rules ("cannot delete last layer") from unexpected `Internal` errors |
| `Layer::duplicate()` resets `locked: false` | UX standard (Photoshop/Krita): duplicated layers are always editable |
| Thumbnail as raw RGBA in DTO | At 16x16 (~1KB/layer), inline delivery is simpler than a separate fetch command |
| Monotonic `layerNameCounter` | `layers.length + 1` desyncs after deletions; counter ensures unique names |

## Out of scope

- Opacity editing (slider/input) — display only per spec
- Layer effects, masks, grouping
- List virtualization (not needed for ≤50 layers per SC-007)
- Frontend-to-backend `set_active_layer` command (selection is frontend-only for latency)

## Verification

- `cargo test`: 264 passed, 0 failed
- `npx vitest run`: 168 passed (12 suites), 0 failed
- `npm run typecheck`: clean
- `npx biome check`: 0 errors in changed files
- `/speckit.verify`: 0 critical, 0 high issues
- `/speckit.review`: all agents passed, findings addressed

## How to test

```bash
# Backend
cd src-tauri && cargo test

# Frontend
npm install
npx vitest run

# Type check + lint
npm run typecheck
npx biome check src/components/layers/

# Manual: run the app
npm run tauri dev
# Open/create a texture → Layers panel shows layers
# Click rows to select, +/trash/copy buttons, double-click to rename
# Drag rows to reorder, click eye to toggle visibility
# Change blend mode from dropdown, press Delete to remove layer
```