### PR TITLE
fix: refactor undo/redo with targeted payloads and mid-stroke handling

### DIFF
--- a/specs/035-fix-undo-redo/checklists/requirements.md
+++ b/specs/035-fix-undo-redo/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Fix Undo/Redo System
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The issue references Blockbench/Krita implementations and specific Rust code paths — these were intentionally excluded from the spec to keep it technology-agnostic. They will inform the planning phase.

--- a/specs/035-fix-undo-redo/contracts/tauri-ipc.md
+++ b/specs/035-fix-undo-redo/contracts/tauri-ipc.md
@@ -1,0 +1,94 @@
+# IPC Contracts: Undo/Redo System
+
+**Feature**: 035-fix-undo-redo | **Date**: 2026-04-10
+
+## Overview
+
+The undo/redo system communicates between frontend and backend via Tauri IPC commands. This feature does NOT change any IPC signatures — the existing `undo`, `redo`, `tool_press`, `tool_drag`, and `tool_release` commands retain their exact input/output types. The changes are entirely within the backend behavior.
+
+## Existing Commands (no signature change)
+
+### `undo` → `Result<EditorStateDto, AppError>`
+
+**Current behavior**: Pops from undo stack, restores snapshot, pushes to redo stack.
+
+**New behavior**: If a stroke is in progress (`pending_snapshot` is populated):
+1. Finalizes the in-progress stroke (pushes as undo entry if pixels were modified)
+2. Clears active tool instance
+3. Then proceeds with normal undo (pops the just-finalized stroke entry)
+
+The DTO return type and structure are unchanged. The `canUndo` and `canRedo` fields in `EditorStateDto` reflect the post-operation state.
+
+**Error cases** (unchanged):
+- `AppError::NoEditorOpen` — no texture is open
+- `AppError::Domain(DomainError::EmptyHistory)` — nothing to undo (after potential finalization)
+
+---
+
+### `redo` → `Result<EditorStateDto, AppError>`
+
+**No behavioral change**. Redo is not affected by mid-stroke finalization (you can't redo during a stroke — there's nothing to redo). If somehow called mid-stroke, it operates normally on the redo stack.
+
+---
+
+### `tool_press` → `Result<ToolResultDto, AppError>`
+
+**No change**. Continues to start a new stroke cycle and capture a pending snapshot.
+
+---
+
+### `tool_drag` → `Result<ToolResultDto, AppError>`
+
+**No change**. Continues to apply drag phase to the active tool.
+
+**New edge case**: If `undo` was called mid-stroke (clearing the active tool), a subsequent `tool_drag` call returns `AppError::Internal("no active tool")`. The frontend already handles this error in `useViewportControls.ts` via the error catch in `processDrag()`.
+
+---
+
+### `tool_release` → `Result<ToolResultDto, AppError>`
+
+**No change**. Continues to finalize the stroke and push the undo entry.
+
+**New edge case**: Same as `tool_drag` — if `undo` cleared the active tool, `tool_release` returns an error. The frontend handles this gracefully.
+
+## Events (no change)
+
+### `state-changed` (Tauri event)
+
+Emitted after every state mutation (undo, redo, tool press with pixel modification, tool release, layer operations). No payload — frontend re-fetches state via `getEditorState()`.
+
+No new events are added for mid-stroke cancellation. The existing `state-changed` event after `undo` is sufficient for the frontend to re-sync.
+
+## DTO Structure (no change)
+
+### `EditorStateDto`
+
+```typescript
+interface EditorStateDto {
+  isOpen: boolean;
+  namespace: string | null;
+  path: string | null;
+  width: number | null;
+  height: number | null;
+  isDirty: boolean;
+  canUndo: boolean;    // reflects post-operation state
+  canRedo: boolean;    // reflects post-operation state
+  layers: LayerInfoDto[];
+  activeLayerId: string | null;
+}
+```
+
+### `ToolResultDto`
+
+```typescript
+interface ToolResultDto {
+  resultType: "pixels_modified" | "color_picked" | "selection_changed" | "no_op";
+  composite: number[] | null;  // RGBA flat array if pixels modified
+  pickedColor: ColorDto | null;
+  selection: SelectionDto | null;
+}
+```
+
+## Frontend Impact
+
+No frontend code changes are required for this feature. The existing error handling in `useViewportControls.ts` already handles the case where `tool_drag` / `tool_release` fail (e.g., when no active tool exists after mid-stroke undo). The pointer state (`isDrawingRef`) will be reset on the next `onPointerUp` event.

--- a/specs/035-fix-undo-redo/data-model.md
+++ b/specs/035-fix-undo-redo/data-model.md
@@ -1,0 +1,228 @@
+# Data Model: Fix Undo/Redo System
+
+**Feature**: 035-fix-undo-redo | **Date**: 2026-04-10
+
+## Entity Changes
+
+### Modified: `UndoEntry` (domain/undo.rs)
+
+The `UndoEntry` struct replaces its `TextureSnapshot` field with a discriminated `UndoPayload`.
+
+```rust
+pub struct UndoEntry {
+    operation: OperationType,
+    payload: UndoPayload,  // was: snapshot: TextureSnapshot
+}
+```
+
+**Invariant**: The `payload` variant must be consistent with the `operation` type:
+- `OperationType::Draw` → `UndoPayload::SingleLayer`
+- `OperationType::LayerPropertyChange` → `UndoPayload::Property`
+- `OperationType::LayerAdd | LayerRemove | LayerReorder` → `UndoPayload::FullStack`
+
+---
+
+### New: `UndoPayload` (domain/undo.rs)
+
+Discriminated union representing the minimum data needed to reverse an operation.
+
+```rust
+pub enum UndoPayload {
+    /// Full pixel snapshot of a single affected layer (for draw operations).
+    /// Constitution Principle VI: "full-layer snapshots, not diff-based."
+    SingleLayer(LayerSnapshot),
+
+    /// Full layer stack snapshot (for structural changes: add, remove, reorder).
+    /// Captures all layers to enable symmetric undo/redo swap.
+    FullStack(TextureSnapshot),
+
+    /// Metadata-only snapshot for a single layer property change.
+    /// No pixel data — only the old value of the changed property.
+    Property {
+        layer_id: LayerId,
+        change: PropertyChange,
+    },
+}
+```
+
+**Validation rules**:
+- `SingleLayer`: The `LayerSnapshot.id` must correspond to a layer that existed when the entry was created. On restore, the layer must still exist (structural changes would have their own entries).
+- `FullStack`: The snapshot must contain at least one `LayerSnapshot` (textures always have >= 1 layer for structural operations that modify the count).
+- `Property`: The `layer_id` must be valid. The `PropertyChange` variant must match the property that was actually changed.
+
+---
+
+### New: `PropertyChange` (domain/undo.rs)
+
+Enum representing the old value of a single layer property.
+
+```rust
+pub enum PropertyChange {
+    Opacity(f32),
+    BlendMode(BlendMode),
+    Visibility(bool),
+    Name(String),
+    Locked(bool),
+}
+```
+
+**Validation rules**:
+- `Opacity`: Must be in range [0.0, 1.0] (enforced by `Layer::set_opacity` clamp)
+- `BlendMode`: Must be a valid `BlendMode` variant
+- `Name`: Must be non-empty (enforced by `Layer::set_name`)
+
+---
+
+### Unchanged: `LayerSnapshot` (domain/undo.rs)
+
+No structural changes. Already captures a single layer's complete state (id, name, pixel data, opacity, blend mode, visibility, locked). Used by `UndoPayload::SingleLayer`.
+
+---
+
+### Unchanged: `TextureSnapshot` (domain/undo.rs)
+
+No structural changes. Captures all layers via `Vec<LayerSnapshot>`. Used by `UndoPayload::FullStack`.
+
+---
+
+### Unchanged: `OperationType` (domain/undo.rs)
+
+```rust
+pub enum OperationType {
+    Draw,
+    LayerAdd,
+    LayerRemove,
+    LayerReorder,
+    LayerPropertyChange,
+}
+```
+
+No changes. The five operation types remain the same.
+
+---
+
+### Unchanged: `UndoManager` (domain/undo.rs)
+
+No structural changes to `UndoManager`. It manages `VecDeque<UndoEntry>` (undo stack) and `Vec<UndoEntry>` (redo stack) with bounded depth. The internal logic (push, pop, clear, max_depth eviction) is payload-agnostic.
+
+---
+
+### Modified: `EditorService` (use_cases/editor_service.rs)
+
+**New field**:
+```rust
+pub struct EditorService {
+    texture: Texture,
+    undo_manager: UndoManager,
+    pending_snapshot: Option<TextureSnapshot>,       // CHANGED TYPE — see below
+    pixels_modified_in_cycle: bool,
+    pending_draw_layer_id: Option<LayerId>,           // NEW
+}
+```
+
+**`pending_snapshot` type change**: Stays as `Option<TextureSnapshot>` during the press phase (we still capture a full snapshot at press time for safety). At release time, the snapshot is narrowed to `SingleLayer` by extracting only the affected layer's data.
+
+**`pending_draw_layer_id`**: Tracks which layer the current stroke is targeting. Set on `apply_tool_press`, cleared on `apply_tool_release`. Used during mid-stroke finalization to extract the correct layer from the pending snapshot.
+
+---
+
+## State Transitions
+
+### Stroke Lifecycle (press → drag → release)
+
+```
+State: idle
+  pending_snapshot = None
+  pending_draw_layer_id = None
+  pixels_modified_in_cycle = false
+
+→ apply_tool_press(layer_id)
+  pending_snapshot = Some(TextureSnapshot::capture(layer_stack))
+  pending_draw_layer_id = Some(layer_id)
+  pixels_modified_in_cycle = false
+
+State: active_stroke
+  pending_snapshot = Some(...)
+  pending_draw_layer_id = Some(id)
+
+→ apply_tool_drag(layer_id)
+  pixels_modified_in_cycle |= (result == PixelsModified)
+
+→ apply_tool_release(layer_id)
+  if pixels_modified_in_cycle:
+    extract affected layer from pending_snapshot → SingleLayer payload
+    push UndoEntry(Draw, SingleLayer(layer_snapshot))
+  pending_snapshot = None
+  pending_draw_layer_id = None
+  pixels_modified_in_cycle = false
+
+State: idle (back to start)
+```
+
+### Mid-Stroke Undo
+
+```
+State: active_stroke
+  pending_snapshot = Some(...)
+  pending_draw_layer_id = Some(id)
+  pixels_modified_in_cycle = true/false
+
+→ undo() called
+  if pending_snapshot.is_some():
+    FINALIZE:
+      if pixels_modified_in_cycle:
+        extract affected layer → push UndoEntry(Draw, SingleLayer(...))
+      clear pending_snapshot, pending_draw_layer_id, pixels_modified_in_cycle
+    PROCEED: normal undo (pop top of undo stack)
+  else:
+    normal undo
+
+State: idle
+  (active_tool cleared in command layer)
+```
+
+### Undo/Redo Restore (per payload variant)
+
+```
+undo/redo:
+  entry = pop from source stack
+  
+  match entry.payload:
+    SingleLayer(old_layer):
+      current_layer = snapshot current state of layer[old_layer.id]
+      restore layer[old_layer.id] from old_layer
+      push UndoEntry(op, SingleLayer(current_layer)) to target stack
+      
+    FullStack(old_texture):
+      current_texture = snapshot all layers
+      restore layer_stack from old_texture
+      push UndoEntry(op, FullStack(current_texture)) to target stack
+      
+    Property { layer_id, change: old_value }:
+      current_value = read current property from layer[layer_id]
+      set property on layer[layer_id] to old_value
+      push UndoEntry(op, Property { layer_id, change: current_value }) to target stack
+```
+
+## Relationships
+
+```
+UndoManager
+  ├── undo_stack: VecDeque<UndoEntry>
+  └── redo_stack: Vec<UndoEntry>
+
+UndoEntry
+  ├── operation: OperationType
+  └── payload: UndoPayload
+       ├── SingleLayer(LayerSnapshot)
+       ├── FullStack(TextureSnapshot)
+       │    └── layers: Vec<LayerSnapshot>
+       └── Property { layer_id: LayerId, change: PropertyChange }
+
+EditorService
+  ├── texture: Texture
+  ├── undo_manager: UndoManager
+  ├── pending_snapshot: Option<TextureSnapshot>
+  ├── pending_draw_layer_id: Option<LayerId>
+  └── pixels_modified_in_cycle: bool
+```

--- a/specs/035-fix-undo-redo/plan.md
+++ b/specs/035-fix-undo-redo/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Fix Undo/Redo System
+
+**Branch**: `035-fix-undo-redo` | **Date**: 2026-04-10 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/035-fix-undo-redo/spec.md`
+
+## Summary
+
+The current undo/redo system captures a full `TextureSnapshot` (all layers, all pixel data) for every operation — draws, property changes, and structural changes alike. This is wasteful and doesn't match the expected granularity described in the spec. Additionally, triggering undo mid-stroke (mouse held down) has no finalization logic, risking state corruption. This plan refactors the snapshot architecture to use targeted payloads (single-layer for draws, metadata-only for property changes, full-stack only for structural changes), adds mid-stroke undo finalization, and ensures stroke boundaries are correct regardless of input speed.
+
+## Technical Context
+
+**Language/Version**: Rust 1.77+ (backend), TypeScript 5.7 (frontend)
+**Primary Dependencies**: tauri ^2.10, image ^0.25, React 19, Zustand 5
+**Storage**: In-memory (`Mutex<AppState>`), .texlab archives (ZIP) for persistence
+**Testing**: `cargo test` (Rust domain + use_cases), vitest planned (frontend)
+**Target Platform**: Windows, macOS, Linux (desktop via Tauri)
+**Project Type**: Desktop application (Tauri v2)
+**Performance Goals**: Undo/redo < 1ms for typical Minecraft textures (16x16 to 64x64)
+**Constraints**: Memory proportional to changes, not total texture size * history depth
+**Scale/Scope**: Textures 16x16 to 512x512, 1-20 layers, 100-entry history limit
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Design Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Clean Architecture | PASS | All changes stay within domain/ and use_cases/. No new infra or framework deps. |
+| II. Domain Purity | PASS | New `UndoPayload` enum is pure Rust, no external crates. No serde on domain types. |
+| III. Dual-Access State | PASS | Undo/redo operates via `EditorService`; both Tauri commands and MCP call the same code paths. |
+| IV. Test-First Domain | PASS | All new undo types and EditorService changes will have unit tests. In-memory only. |
+| V. Progressive Processing | N/A | No change to .texlab conversion flow. |
+| VI. Simplicity | REVIEW | **Tension**: Constitution says "full-layer snapshots, not diff-based." Spec FR-005/006/007 require targeted capture. Resolution: we still use full-layer snapshots (not pixel diffs), but only for the AFFECTED layer. Property changes use metadata-only payloads. Structural changes (add/remove/reorder) keep full-stack snapshots for simplicity. See research.md for full rationale. |
+| VII. Component-Based UI | PASS | No panel layout changes. Frontend only needs to handle mid-stroke undo coordination. |
+
+**Gate result**: PASS (with justified Principle VI refinement for FR-005/006)
+
+### Post-Design Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Clean Architecture | PASS | `UndoPayload`, `PropertyChange` live in `domain/undo.rs`. `EditorService` in `use_cases/`. `history_commands.rs` in `commands/`. No layer violations. |
+| II. Domain Purity | PASS | New types use only `LayerId`, `BlendMode`, `f32`, `bool`, `String` — all domain or std. Zero external deps. |
+| III. Dual-Access State | PASS | Mid-stroke finalization is in `EditorService::undo()`. Both Tauri commands and MCP call the same method. No divergent code paths. |
+| IV. Test-First Domain | PASS | 8 new test scenarios defined in quickstart.md. All exercisable with in-memory `EditorService` and domain types. |
+| V. Progressive Processing | N/A | No change to .texlab conversion. |
+| VI. Simplicity | PASS | Constitution says "full-layer snapshots, not diff-based." Design preserves this — `SingleLayer` stores the full layer buffer (not pixel diffs). `PropertyChange` avoids snapshotting pixel data for metadata changes. `FullStack` for structural ops keeps the simplest correct approach. 3 code paths, not per-operation-type. |
+| VII. Component-Based UI | PASS | No frontend changes needed. Existing error handling covers mid-stroke undo edge case. |
+
+**Gate result**: PASS — all principles satisfied. Principle VI tension resolved per research.md R1.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/035-fix-undo-redo/
+├── plan.md              # This file
+├── research.md          # Phase 0: design decisions and rationale
+├── data-model.md        # Phase 1: domain model changes
+├── quickstart.md        # Phase 1: dev quickstart
+├── contracts/           # Phase 1: IPC contract changes
+│   └── tauri-ipc.md     # Undo/redo command contracts
+└── tasks.md             # Phase 2 (/speckit.tasks — NOT created here)
+```
+
+### Source Code (affected files)
+
+```text
+src-tauri/src/
+  domain/
+    undo.rs              # MAJOR: Replace TextureSnapshot-only with UndoPayload enum
+    layer_stack.rs       # MINOR: Add single-layer restore method
+  use_cases/
+    editor_service.rs    # MAJOR: Targeted snapshots, mid-stroke finalization, new undo/redo logic
+  commands/
+    history_commands.rs  # MINOR: Mid-stroke finalization in undo command
+    tool_commands.rs     # NO CHANGE (stroke lifecycle stays the same)
+
+src/
+  commands/
+    definitions/edit.ts  # NO CHANGE (keybindings remain the same)
+  api/
+    commands.ts          # NO CHANGE (undo/redo API signatures unchanged)
+```
+
+## Complexity Tracking
+
+| Deviation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Targeted `UndoPayload` vs uniform `TextureSnapshot` | FR-005/006: memory proportional to changes. A property rename shouldn't clone all pixel data. | Full texture snapshots for everything is O(layers * pixels * history). For 5 layers on 64x64 with 100 entries = 40MB. Targeted payloads: ~1MB for same scenario. |
+| Full-stack snapshots for structural ops (add/remove/reorder) | Simplicity: inverse command pattern for structural changes adds complexity with asymmetric undo/redo. | Per-FR-007 "capture only structural change + affected data" — but full-stack for structural ops is still simple and correct. These ops are infrequent vs draws. Constitution VI justifies this. |

--- a/specs/035-fix-undo-redo/quickstart.md
+++ b/specs/035-fix-undo-redo/quickstart.md
@@ -1,0 +1,66 @@
+# Quickstart: Fix Undo/Redo System
+
+**Feature**: 035-fix-undo-redo | **Date**: 2026-04-10
+
+## Prerequisites
+
+- Rust >= 1.77 with `cargo` installed
+- Node.js >= 20 LTS with `npm`
+- Tauri v2 CLI: `cargo install tauri-cli --version "^2"`
+
+## Build & Run
+
+```bash
+# From project root
+cd apps/texture-lab
+
+# Install frontend dependencies
+npm install
+
+# Run in development mode (hot reload)
+cargo tauri dev
+
+# Run Rust tests only (no frontend needed)
+cd src-tauri && cargo test
+```
+
+## Key Files to Modify
+
+| File | Change Scope | Purpose |
+|------|-------------|---------|
+| `src-tauri/src/domain/undo.rs` | MAJOR | Add `UndoPayload`, `PropertyChange` enums. Update `UndoEntry` to use `UndoPayload` instead of `TextureSnapshot`. |
+| `src-tauri/src/use_cases/editor_service.rs` | MAJOR | Targeted snapshot capture per operation type. Mid-stroke finalization in `undo()`. New restore logic per payload variant. Add `pending_draw_layer_id` field. |
+| `src-tauri/src/domain/layer_stack.rs` | MINOR | Add `restore_single_layer(LayerSnapshot)` method for single-layer restore. |
+| `src-tauri/src/commands/history_commands.rs` | MINOR | Clear `active_tool` after mid-stroke undo finalization. |
+
+## Test Strategy
+
+All tests are in-memory Rust unit tests. No real file I/O.
+
+```bash
+# Run all tests
+cd src-tauri && cargo test
+
+# Run only undo-related tests
+cd src-tauri && cargo test undo
+
+# Run only editor_service tests
+cd src-tauri && cargo test editor_service
+```
+
+### Test Coverage Required
+
+1. **Targeted snapshots**: Verify that a draw undo entry contains only the affected layer's data, not all layers.
+2. **Property undo round-trip**: Change opacity → undo → verify old opacity restored, no pixel data in entry.
+3. **Mid-stroke undo**: Press → drag (modify pixels) → undo → verify stroke is cancelled and canvas is clean.
+4. **Mid-stroke undo with no modification**: Press → undo (no drag) → verify no empty entry pushed, previous action undone.
+5. **Rapid strokes**: Multiple press/release cycles → verify each has its own undo entry.
+6. **Mixed operations**: Draw + layer add + property change → undo all three → verify correct state at each step.
+7. **History limit**: Push > max_depth entries → verify oldest evicted, newest retained.
+8. **Redo after mid-stroke undo**: Mid-stroke undo → redo → verify stroke is restored.
+
+## Architecture Notes
+
+- **Domain purity**: `UndoPayload` and `PropertyChange` are in `domain/undo.rs`. They use only domain types. No serde, no tauri, no external crates.
+- **Symmetric swap**: SingleLayer and FullStack variants use the same capture-restore-push pattern. Property uses a simpler read-write-push pattern.
+- **Constitution compliance**: "Full-layer snapshots, not diff-based" — SingleLayer stores the complete layer buffer, not pixel diffs. We just don't snapshot unaffected layers.

--- a/specs/035-fix-undo-redo/research.md
+++ b/specs/035-fix-undo-redo/research.md
@@ -1,0 +1,185 @@
+# Research: Fix Undo/Redo System
+
+**Feature**: 035-fix-undo-redo | **Date**: 2026-04-10
+
+## R1: Snapshot Architecture — Full-Stack vs Targeted Payloads
+
+### Context
+
+The current system stores a `TextureSnapshot` (all layers, all pixel data) for every undo entry, regardless of operation type. The constitution (Principle VI) states: "Undo/redo uses full-layer snapshots, not diff-based." The spec (FR-005/006/007) requires capturing only affected data.
+
+### Decision: Discriminated `UndoPayload` enum
+
+Replace the uniform `TextureSnapshot` with a three-variant enum:
+
+1. **`SingleLayer(LayerSnapshot)`** — for draw operations. Captures the full pixel data of the ONE affected layer before the stroke. Aligned with the constitution's "full-layer snapshots" principle — we snapshot the entire layer, not pixel diffs. The optimization is avoiding snapshots of unaffected layers.
+
+2. **`Property { layer_id, old_value }`** — for layer property changes (opacity, blend mode, visibility, name, locked). Captures only the changed metadata. No pixel data. Obviously simpler and more efficient than snapshotting pixel data for a name change.
+
+3. **`FullStack(TextureSnapshot)`** — for structural changes (add, remove, reorder). Captures the full layer stack before the operation. This is the same as current behavior.
+
+### Rationale
+
+- **Memory impact**: For a 5-layer 64x64 texture with 100 history entries, full-stack everywhere = ~40MB. With targeted payloads, a typical session (80% draws on 1 layer, 15% property changes, 5% structural) = ~6MB. A 6x reduction.
+- **Constitution compliance**: "Full-layer snapshots, not diff-based" is preserved — draw entries store the complete layer buffer, not pixel-level patches. We simply don't snapshot layers that weren't touched.
+- **Simplicity**: The symmetric swap pattern (`apply_history_swap`) still works for SingleLayer and FullStack. Property changes use a simpler capture/restore pair. Only 3 code paths instead of per-operation-type logic.
+
+### Alternatives Considered
+
+| Alternative | Rejected Because |
+|-------------|-----------------|
+| **Pixel diff/patch per stroke** | Violates constitution Principle VI. Complex to implement correctly (bounding box tracking, delta encoding). Over-engineering for Minecraft texture sizes. |
+| **Command pattern (inverse operations)** | Asymmetric undo/redo logic per operation type. Structural changes become complex (re-inserting layers with exact pixel data requires storing the layer anyway). More code, more bugs. |
+| **Keep full TextureSnapshot everywhere** | Violates FR-005/006. Wastes memory for property changes. Doesn't scale if users work with larger textures or more layers. |
+| **Targeted per structural op type** (LayerAdded stores only new ID, LayerRemoved stores removed layer + index) | Breaks the symmetric swap pattern. Requires different restore logic for undo vs redo per structural variant. Higher complexity with marginal memory savings (structural ops are infrequent). |
+
+---
+
+## R2: Mid-Stroke Undo Finalization
+
+### Context
+
+If the user presses Ctrl+Z while a stroke is in progress (mouse held down), the current system calls `EditorService::undo()` directly. The `pending_snapshot` field is populated but the stroke hasn't been finalized. This means:
+- Undo operates on the previous entry, but the in-progress pixels remain on the canvas
+- The pending snapshot is orphaned (never pushed to the undo stack)
+- The canvas state diverges from history state = corruption
+
+### Decision: Finalize-then-undo in `EditorService::undo()`
+
+When `undo()` is called and `pending_snapshot` is `Some`:
+1. **Finalize**: If `pixels_modified_in_cycle` is true, push the pending snapshot as a `Draw` undo entry. Clear `pending_snapshot` and `pixels_modified_in_cycle`.
+2. **Proceed with undo**: The just-finalized stroke is now the top of the undo stack. Normal undo pops it, restoring to before the stroke.
+
+Net effect: mid-stroke Ctrl+Z cleanly cancels the in-progress stroke. The stroke is recorded as an undo entry so Ctrl+Y can redo it.
+
+If no pixels were modified during the stroke, the pending snapshot is simply discarded and normal undo proceeds.
+
+### Rationale
+
+- **Backend-authoritative**: The finalization logic lives in `EditorService`, not the frontend. This ensures consistency regardless of how undo is triggered (keyboard, command palette, MCP).
+- **No frontend coordination needed**: The frontend undo command (`edit.undo`) doesn't need to know about stroke state. It calls `invoke("undo")` and the backend handles everything.
+- **Atomic**: Lock is already held during the undo command, so finalization + undo happen in one atomic operation.
+
+### Alternatives Considered
+
+| Alternative | Rejected Because |
+|-------------|-----------------|
+| **Frontend checks stroke state before undo** | Violates Principle III (dual-access). MCP would need separate logic. State split between frontend and backend. |
+| **Disable undo during active stroke** | Poor UX. Users commonly press Ctrl+Z mid-stroke to cancel. Every major editor supports this. |
+| **Cancel stroke without undo entry** | Spec requires stroke finalization as an undo entry (US3-AS1). User should be able to redo the cancelled stroke. |
+
+---
+
+## R3: Stroke Boundary Correctness Under Rapid Input
+
+### Context
+
+The spec (FR-002) requires separate undo entries for strokes drawn in rapid succession (< 500ms apart). The issue title mentions "stroke grouping" as a bug.
+
+### Decision: Current architecture is already correct — no change needed
+
+Analysis of the current code:
+- `apply_tool_press()` captures a new `pending_snapshot` at the START of every stroke
+- `apply_tool_release()` pushes the snapshot at the END of every stroke (if pixels modified)
+- Each press-drag-release cycle is independent — no timer, no debounce, no grouping
+
+The stroke boundary is defined by the press/release pointer events, not by timing. The frontend dispatches these 1:1 with pointer events via `onPointerDown` / `onPointerUp`. There is no batching or merging of press/release events.
+
+**Verification**: The existing test `multiple_operations_sequential_undo_in_reverse_order` confirms two back-to-back strokes produce two independent undo entries.
+
+### Rationale
+
+No code change is needed. The "stroke grouping" mentioned in the issue title likely referred to the overall architecture review, not a specific timing bug. The current 1:1 stroke-to-entry mapping is correct by design.
+
+### Risk Assessment
+
+The only theoretical risk is if the frontend's `processDrag()` serialization (using `dragInFlightRef`) somehow loses a `tool_release` event. Inspection shows that `onPointerUp` always calls `toolRelease()` regardless of pending drag state, so this path is safe.
+
+---
+
+## R4: Undo/Redo Restore Logic Per Payload Type
+
+### Context
+
+The current `apply_history_swap` is generic — it captures the full texture state, restores from the popped entry, and pushes the captured state. With targeted payloads, we need type-specific restore logic.
+
+### Decision: Match-based restore with symmetric capture
+
+```
+fn undo/redo:
+  match popped_entry.payload:
+    SingleLayer(old_snapshot):
+      current_snapshot = LayerSnapshot::from_layer(find_layer(old_snapshot.id))
+      layer.restore_from_snapshot(old_snapshot)
+      push(SingleLayer(current_snapshot))
+      
+    FullStack(old_texture):
+      current_texture = TextureSnapshot::capture(layer_stack)
+      layer_stack.restore_from_snapshots(old_texture)
+      push(FullStack(current_texture))
+      
+    Property { layer_id, old_value }:
+      current_value = read_property(layer_id, old_value.kind())
+      set_property(layer_id, old_value)
+      push(Property { layer_id, current_value })
+```
+
+### Rationale
+
+- **Symmetric**: Each variant captures the current state in the same format before restoring. Undo and redo use the exact same code path (just swapping which stack to pop from and push to).
+- **Type-safe**: The match ensures every payload variant has explicit restore logic. No accidental fallthrough.
+- **Efficient**: SingleLayer only reads/writes one layer. Property only reads/writes one field. FullStack works as before.
+
+---
+
+## R5: `PropertyChange` Enum Design
+
+### Context
+
+FR-006 requires property change undo entries to capture "only the changed metadata." We need a type to represent the old value of any layer property.
+
+### Decision: Flat enum with one variant per property
+
+```rust
+enum PropertyChange {
+    Opacity(f32),
+    BlendMode(BlendMode),
+    Visibility(bool),
+    Name(String),
+    Locked(bool),
+}
+```
+
+### Rationale
+
+- **Exhaustive**: Every settable layer property has a variant.
+- **Simple**: No nested structs, no generics. Each variant carries exactly the old value.
+- **Extensible**: Adding a new layer property means adding one variant and one match arm.
+- **Domain-pure**: Uses only domain types (`BlendMode`, `f32`, `bool`, `String`).
+
+---
+
+## R6: History Command Mid-Stroke Coordination
+
+### Context
+
+The Tauri `undo` command in `history_commands.rs` currently calls `state.editor_mut()?.undo()`. But mid-stroke, the tool instance is stored in `AppState.active_tool`. After mid-stroke finalization, the tool should be cleared to prevent the frontend from sending further drag/release events for a stroke that no longer exists.
+
+### Decision: Clear `active_tool` during mid-stroke undo in the command layer
+
+In `history_commands.rs`, after the editor finalizes and undoes:
+1. Check if `pending_snapshot` was present (indicates mid-stroke)
+2. If yes, set `state.active_tool = None` (drop the tool instance)
+3. This signals the frontend that the stroke is over
+
+The frontend already handles missing `active_tool` gracefully — `tool_drag` and `tool_release` return an error if no active tool exists. The frontend can catch this and reset its pointer state.
+
+### Rationale
+
+- Backend stays authoritative — the tool lifecycle is managed in Rust, not JS
+- Frontend error handling is already in place (error catch in `useViewportControls`)
+- No new IPC event needed — the existing `state-changed` emission after undo is sufficient for the frontend to re-sync
+
+### Alternative: Emit a dedicated `stroke-cancelled` event
+
+Rejected because it adds a new event type for a rare edge case. The existing error path + state-changed event is sufficient.

--- a/specs/035-fix-undo-redo/spec.md
+++ b/specs/035-fix-undo-redo/spec.md
@@ -1,0 +1,157 @@
+# Feature Specification: Fix Undo/Redo System
+
+**Feature Branch**: `035-fix-undo-redo`  
+**Created**: 2026-04-10  
+**Status**: Draft  
+**Input**: GitHub Issue #35 — Fix undo/redo: stroke grouping, layer operations, and snapshot architecture
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Undo individual paint strokes (Priority: P1)
+
+A user draws a paint stroke on the canvas (mouse down, drag, mouse up), then presses Ctrl+Z. Only the last completed stroke is removed. The canvas returns to its state before that stroke. The user can press Ctrl+Z again to undo the stroke before that, and so on.
+
+**Why this priority**: This is the most fundamental undo behavior. Every pixel editor relies on stroke-level undo granularity. Without it, the editor is unusable for iterative work.
+
+**Independent Test**: Draw three separate strokes with pauses between them. Press Ctrl+Z three times. Each press should remove exactly one stroke in reverse order.
+
+**Acceptance Scenarios**:
+
+1. **Given** a canvas with existing content, **When** the user draws one stroke (press, drag, release) and presses Ctrl+Z, **Then** only that stroke is removed and the canvas returns to its pre-stroke state.
+2. **Given** a canvas where the user has drawn five strokes, **When** the user presses Ctrl+Z five times, **Then** each press removes exactly one stroke in reverse chronological order.
+3. **Given** a canvas with no undo history, **When** the user presses Ctrl+Z, **Then** nothing happens and the canvas remains unchanged.
+
+---
+
+### User Story 2 - Undo rapid successive strokes independently (Priority: P1)
+
+A user draws multiple short strokes in quick succession (click-release-click-release rapidly). Each stroke is recorded as a separate undo entry. Pressing Ctrl+Z undoes them one at a time, regardless of the speed at which they were created.
+
+**Why this priority**: This is the core bug reported. Users naturally draw quickly, and merging strokes into a single undo block breaks the fundamental editing contract.
+
+**Independent Test**: Rapidly draw 4 strokes in quick succession (< 500ms between each). Press Ctrl+Z four times. Each press should remove exactly one stroke.
+
+**Acceptance Scenarios**:
+
+1. **Given** a canvas, **When** the user draws three strokes rapidly (each within 500ms of the previous), **Then** three separate undo entries are created.
+2. **Given** three rapidly-drawn strokes, **When** the user presses Ctrl+Z once, **Then** only the last stroke is removed, not all three.
+3. **Given** three rapidly-drawn strokes, **When** the user presses Ctrl+Z three times, **Then** each stroke is removed individually in reverse order.
+
+---
+
+### User Story 3 - Undo during active stroke (Priority: P2)
+
+A user is in the middle of drawing a stroke (mouse is still held down). The user presses Ctrl+Z. The system first completes/finalizes the in-progress stroke as one undo entry, then undoes the previous completed action. The canvas state remains consistent.
+
+**Why this priority**: While less common than post-stroke undo, mid-stroke undo currently corrupts state, which is a data integrity issue.
+
+**Independent Test**: Draw one stroke, then start a second stroke. While holding the mouse button, press Ctrl+Z. The in-progress stroke should be finalized, then the previous action should be undone.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is mid-stroke (mouse held down), **When** the user presses Ctrl+Z, **Then** the current stroke is finalized as a complete undo entry before any undo operation occurs.
+2. **Given** a finalized mid-stroke followed by an undo, **When** the user presses Ctrl+Y (redo), **Then** the previously undone action is restored correctly.
+3. **Given** a user is mid-stroke, **When** the user presses Ctrl+Z, **Then** subsequent undo/redo operations remain consistent and no state corruption occurs.
+
+---
+
+### User Story 4 - Undo layer operations individually (Priority: P2)
+
+A user performs layer operations such as adding a layer, renaming it, reordering layers, toggling visibility, changing blend mode, or adjusting opacity. Each operation is recorded as a separate undo entry. Pressing Ctrl+Z undoes the last layer operation without affecting unrelated pixel data.
+
+**Why this priority**: Layer management is a core editing workflow. Users expect layer operations to be undoable individually, just like paint strokes.
+
+**Independent Test**: Add a layer, rename it, then change its blend mode. Press Ctrl+Z three times. Each press should reverse one operation: first the blend mode change, then the rename, then the layer addition.
+
+**Acceptance Scenarios**:
+
+1. **Given** a texture with one layer, **When** the user adds a new layer and presses Ctrl+Z, **Then** only the layer addition is undone and the new layer is removed.
+2. **Given** a layer named "Layer 1", **When** the user renames it to "Background" and presses Ctrl+Z, **Then** the name reverts to "Layer 1".
+3. **Given** two layers in order A-B, **When** the user reorders them to B-A and presses Ctrl+Z, **Then** the order reverts to A-B.
+4. **Given** a visible layer, **When** the user hides it and presses Ctrl+Z, **Then** the layer becomes visible again.
+5. **Given** a layer with "Normal" blend mode, **When** the user changes it to "Multiply" and presses Ctrl+Z, **Then** the blend mode reverts to "Normal".
+6. **Given** a layer at 100% opacity, **When** the user sets it to 50% and presses Ctrl+Z, **Then** the opacity reverts to 100%.
+
+---
+
+### User Story 5 - Redo after undo (Priority: P2)
+
+After undoing one or more actions, the user can redo them with Ctrl+Y (or Ctrl+Shift+Z). Redo restores the undone actions in order. Performing a new action after undo clears the redo stack.
+
+**Why this priority**: Redo is the complement to undo. It must work correctly with all the undo fixes to provide a complete editing experience.
+
+**Independent Test**: Draw two strokes. Undo both. Redo one. Verify the first stroke reappears. Draw a new stroke. Verify redo is no longer available.
+
+**Acceptance Scenarios**:
+
+1. **Given** two undone strokes, **When** the user presses Ctrl+Y, **Then** the most recently undone stroke is restored.
+2. **Given** one undone stroke and a redo available, **When** the user draws a new stroke, **Then** the redo stack is cleared and the new stroke becomes the latest undo entry.
+3. **Given** an empty redo stack, **When** the user presses Ctrl+Y, **Then** nothing happens.
+
+---
+
+### User Story 6 - Efficient undo capture (Priority: P3)
+
+Undo entries capture only the data that was actually modified by the action. A paint stroke on a single layer captures only that layer's pixel changes. A layer rename captures only the metadata change. The system does not store a full copy of all layers for every action.
+
+**Why this priority**: While not user-visible in behavior, efficient capture is critical for memory usage and performance, especially when working with multi-layer textures. This enables comfortable editing sessions without memory pressure.
+
+**Independent Test**: Perform 50 paint operations on a 5-layer texture. Memory usage should scale with the size of changes made, not with the total texture size multiplied by the number of operations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a texture with 5 layers, **When** the user paints on one layer, **Then** the undo entry captures only the affected layer's data, not all 5 layers.
+2. **Given** a layer property change (rename, visibility, blend mode, opacity), **When** the undo entry is created, **Then** it captures only the changed metadata, not pixel data.
+3. **Given** 50 sequential paint operations on a single layer, **When** examining memory usage, **Then** memory consumed by undo history is proportional to pixels changed, not total texture size times 50.
+
+---
+
+### Edge Cases
+
+- What happens when the undo history reaches maximum capacity? Oldest entries should be discarded first (FIFO) to make room for new ones.
+- What happens when the user performs a compound operation (e.g., delete a layer with painted content)? It should produce a single undo entry that restores both the layer and its content.
+- What happens when the user undoes a layer deletion and then continues editing the restored layer? All subsequent operations should work normally.
+- What happens when the user rapidly alternates between undo and redo? Each operation should execute atomically and the stacks should remain consistent.
+- What happens when there is only one layer and the user tries to undo its creation? The system should follow the existing minimum-layer policy (preventing removal of the last layer, or restoring to a default empty state).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST create exactly one undo entry per completed paint stroke (mouse press, drag, release), regardless of stroke duration or speed.
+- **FR-002**: The system MUST create separate undo entries for consecutively drawn strokes, even when drawn in rapid succession (< 500ms apart).
+- **FR-003**: When the user triggers undo during an active stroke (mouse still held down), the system MUST first finalize the in-progress stroke as a complete undo entry, then undo the previous completed action.
+- **FR-004**: The system MUST create one undo entry per layer operation: add, remove, reorder, rename, visibility toggle, blend mode change, and opacity change.
+- **FR-005**: Undo entries for paint strokes MUST capture only the affected layer's pixel data, not the full texture state.
+- **FR-006**: Undo entries for layer property changes (rename, visibility, blend mode, opacity) MUST capture only the changed metadata.
+- **FR-007**: Undo entries for layer structural changes (add, remove, reorder) SHOULD capture only the structural change and the affected layer data. Full-stack snapshots are acceptable when they provide a simpler and equally correct implementation (per Constitution Principle VI — Simplicity).
+- **FR-008**: Redo MUST restore exactly the action that was undone, in the correct order (LIFO).
+- **FR-009**: Performing any new editing action MUST clear the redo stack entirely.
+- **FR-010**: The undo/redo stacks MUST remain in a consistent state after any combination of draw, undo, redo, and layer operations.
+- **FR-011**: The system MUST enforce a maximum undo history limit, discarding the oldest entries when the limit is reached.
+
+### Key Entities
+
+- **Undo Entry**: A record of a single reversible action, containing the operation type and only the data needed to reverse (and re-apply) it.
+- **Undo Stack**: An ordered collection of undo entries, with the most recent action on top (LIFO).
+- **Redo Stack**: An ordered collection of undone entries available for restoration (LIFO). Cleared when a new action is performed.
+- **Operation Type**: A classification of the action performed (paint stroke, layer add, layer remove, layer reorder, layer property change).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of paint strokes (press, drag, release) produce exactly one independently undoable entry, including strokes drawn in rapid succession (< 500ms apart).
+- **SC-002**: Pressing Ctrl+Z mid-stroke results in a consistent canvas state with no data corruption, verified across 20 rapid mid-stroke undo attempts.
+- **SC-003**: All 6 layer operation types (add, remove, reorder, rename, visibility, blend mode/opacity) are individually undoable and redoable.
+- **SC-004**: Memory consumed by 50 sequential undo entries on a multi-layer texture is proportional to the data changed, not total texture size times 50.
+- **SC-005**: Undo/redo sequences of 100+ operations (mixed paint and layer operations) complete without state inconsistency or data loss.
+
+## Assumptions
+
+- The undo history limit is a reasonable default (e.g., 50-100 entries). Exact value can be configured later.
+- Textures are Minecraft-sized (typically 16x16 to 64x64 pixels, occasionally up to 512x512). Extreme texture sizes (4096x4096+) are not a target for this fix.
+- The existing keyboard shortcut bindings (Ctrl+Z for undo, Ctrl+Y / Ctrl+Shift+Z for redo) remain unchanged. Integration with the command registry from #34 can happen separately.
+- A compound operation (e.g., deleting a layer) produces a single undo entry, not multiple entries for sub-operations.
+- The minimum layer count policy (whether a texture can have zero layers) follows existing application rules and is not changed by this feature.
+- Backend fixes are independent of #34 (Command Registry) as stated in the issue. Both can proceed in parallel.

--- a/specs/035-fix-undo-redo/tasks.md
+++ b/specs/035-fix-undo-redo/tasks.md
@@ -1,0 +1,261 @@
+# Tasks: Fix Undo/Redo System
+
+**Input**: Design documents from `/specs/035-fix-undo-redo/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/tauri-ipc.md, quickstart.md
+
+**Tests**: Included — Constitution Principle IV mandates test-first for domain logic, and spec defines explicit acceptance scenarios.
+
+**Organization**: Tasks grouped by user story. US1+US2 are combined (same code path, both P1).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Exact file paths included in all descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No project scaffolding needed — project already exists. Verify baseline.
+
+- [ ] T001 Run `cargo test` in `src-tauri/` to confirm all existing tests pass before changes
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: New domain types and restore infrastructure that ALL user stories depend on.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T002 Add `PropertyChange` enum (Opacity, BlendMode, Visibility, Name, Locked) in `src-tauri/src/domain/undo.rs`
+- [ ] T003 Add `UndoPayload` enum (SingleLayer, FullStack, Property) in `src-tauri/src/domain/undo.rs`
+- [ ] T004 Update `UndoEntry` to store `UndoPayload` instead of `TextureSnapshot` — update `new()`, `into_parts()`, accessor methods in `src-tauri/src/domain/undo.rs`
+- [ ] T005 [P] Add `restore_single_layer(LayerSnapshot)` method to `LayerStack` that restores a single layer by ID without replacing the entire stack, in `src-tauri/src/domain/layer_stack.rs`
+- [ ] T006 [P] Add `read_property(layer_id, &PropertyChange) -> PropertyChange` and `apply_property(layer_id, PropertyChange)` helper methods on `EditorService` for symmetric property capture/restore in `src-tauri/src/use_cases/editor_service.rs`
+- [ ] T007 Add `pending_draw_layer_id: Option<LayerId>` field to `EditorService` struct, initialize to `None` in constructors, in `src-tauri/src/use_cases/editor_service.rs`
+- [ ] T008 Rewrite `apply_history_swap` to match on `UndoPayload` variant — SingleLayer: capture/restore single layer; FullStack: capture/restore all layers (existing behavior); Property: read/set property value — in `src-tauri/src/use_cases/editor_service.rs`
+- [ ] T009 Update existing `UndoManager` tests in `src-tauri/src/domain/undo.rs` to use `UndoEntry::new(op, UndoPayload::FullStack(...))` instead of `UndoEntry::new(op, TextureSnapshot)`
+- [ ] T010 [P] Add unit tests for `LayerStack::restore_single_layer` — restore preserves other layers, error on unknown ID — in `src-tauri/src/domain/layer_stack.rs`
+
+**Checkpoint**: New types compile. `apply_history_swap` handles all 3 payload variants. All existing tests updated and passing.
+
+---
+
+## Phase 3: User Story 1 + User Story 2 — Undo Individual & Rapid Strokes (Priority: P1) MVP
+
+**Goal**: Each completed paint stroke (press, drag, release) produces exactly one independently undoable entry using a `SingleLayer` payload. Rapid successive strokes (< 500ms apart) create separate entries.
+
+**Independent Test**: Draw three separate strokes. Press Ctrl+Z three times. Each press removes exactly one stroke. Then draw 4 strokes rapidly (< 500ms apart). Press Ctrl+Z four times. Each press removes one stroke.
+
+### Tests
+
+- [ ] T011 [US1] Add unit test: single brush stroke produces `UndoPayload::SingleLayer` entry (not FullStack) in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T012 [US1] Add unit test: undo single stroke restores pixels to pre-stroke state in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T013 [US1] Add unit test: three strokes → three undos → each reverts one stroke in reverse order in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T014 [US2] Add unit test: multiple back-to-back strokes (no delay) produce separate undo entries in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T015 [US1] Add unit test: undo on empty history returns `DomainError::EmptyHistory` (existing test, verify still passes) in `src-tauri/src/use_cases/editor_service.rs` tests
+
+### Implementation
+
+- [ ] T016 [US1] Update `apply_tool_press` to set `pending_draw_layer_id = Some(layer_id)` in `src-tauri/src/use_cases/editor_service.rs`
+- [ ] T017 [US1] Update `apply_tool_release` to extract the affected layer from `pending_snapshot` as `UndoPayload::SingleLayer(layer_snapshot)` using `pending_draw_layer_id`, then push to undo manager, in `src-tauri/src/use_cases/editor_service.rs`
+- [ ] T018 [US1] Clear `pending_draw_layer_id` in `apply_tool_release` (both success and no-modification paths) in `src-tauri/src/use_cases/editor_service.rs`
+- [ ] T019 [US1] Verify all existing `editor_service` stroke tests pass with the new SingleLayer payload — fix any assertion that inspects snapshot internals in `src-tauri/src/use_cases/editor_service.rs` tests
+
+**Checkpoint**: All stroke-level undo tests pass. Each stroke produces a SingleLayer payload. Rapid strokes produce separate entries.
+
+---
+
+## Phase 4: User Story 3 — Undo During Active Stroke (Priority: P2)
+
+**Goal**: Pressing Ctrl+Z mid-stroke (mouse held down) finalizes the in-progress stroke as a complete undo entry, then undoes it (effectively cancelling the stroke). The cancelled stroke is redoable via Ctrl+Y.
+
+**Independent Test**: Draw one stroke. Start a second stroke. While holding mouse, press Ctrl+Z. The second stroke is cleanly cancelled and the canvas shows only the first stroke. Press Ctrl+Y — the second stroke reappears.
+
+### Tests
+
+- [ ] T020 [US3] Add unit test: undo during active stroke with pixels modified — finalizes as entry then undoes it, canvas returns to pre-stroke state — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T021 [US3] Add unit test: undo during active stroke with NO pixels modified — discards pending, undoes previous action — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T022 [US3] Add unit test: redo after mid-stroke undo restores the cancelled stroke — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T023 [US3] Add unit test: subsequent undo/redo operations remain consistent after mid-stroke undo — in `src-tauri/src/use_cases/editor_service.rs` tests
+
+### Implementation
+
+- [ ] T024 [US3] Add mid-stroke finalization logic at the start of `EditorService::undo()` — if `pending_snapshot.is_some()`, finalize the stroke (push SingleLayer entry if pixels modified, clear pending state), then proceed with normal undo — in `src-tauri/src/use_cases/editor_service.rs`
+- [ ] T025 [US3] In `undo` command in `src-tauri/src/commands/history_commands.rs`, after undo completes, check if `active_tool` exists and clear it (`state.active_tool = None`) to signal stroke cancellation
+
+**Checkpoint**: Mid-stroke undo works correctly. Tool state is cleaned up. Redo after mid-stroke undo restores the stroke.
+
+---
+
+## Phase 5: User Story 4 — Undo Layer Operations Individually (Priority: P2)
+
+**Goal**: Each layer operation (add, remove, reorder, rename, visibility, blend mode, opacity, locked) creates a separate undo entry. Property changes use `UndoPayload::Property` (metadata only, no pixel data). Structural changes (add, remove, reorder) use `UndoPayload::FullStack`.
+
+**Independent Test**: Add a layer, rename it, change blend mode. Ctrl+Z three times: first reverts blend mode, then name, then removes the layer.
+
+### Tests
+
+- [ ] T026 [P] [US4] Add unit tests for each layer property: set_opacity, set_blend_mode, set_visibility, set_name, set_locked each produce `UndoPayload::Property` with the correct old value — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T027 [P] [US4] Add unit tests: add_layer and remove_layer produce `UndoPayload::FullStack` — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T028 [US4] Add unit test: undo layer rename reverts name, undo layer opacity reverts value, undo layer add removes the layer — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T029 [US4] Add unit test: mixed draw + layer operations undo in correct reverse order — in `src-tauri/src/use_cases/editor_service.rs` tests
+
+### Implementation
+
+- [ ] T030 [US4] Update `with_layer_undo` to capture `PropertyChange` from the layer's current state before mutation and push `UndoPayload::Property { layer_id, change }` in `src-tauri/src/use_cases/editor_service.rs`
+- [ ] T031 [US4] Update `add_layer`, `add_layer_above`, `duplicate_layer`, `remove_layer`, `move_layer` to push `UndoPayload::FullStack(TextureSnapshot::capture(...))` explicitly in `src-tauri/src/use_cases/editor_service.rs`
+- [ ] T032 [US4] Update existing layer operation tests to account for new payload types in `src-tauri/src/use_cases/editor_service.rs` tests
+
+**Checkpoint**: All layer operations are individually undoable. Property changes store metadata only. Structural changes store full stack.
+
+---
+
+## Phase 6: User Story 5 — Redo After Undo (Priority: P2)
+
+**Goal**: Redo (Ctrl+Y / Ctrl+Shift+Z) restores undone actions correctly for all payload types. New action after undo clears the redo stack. Redo on empty stack is a no-op.
+
+**Independent Test**: Draw two strokes. Undo both. Redo one — first stroke reappears. Draw a new stroke — redo is no longer available.
+
+### Tests
+
+- [ ] T033 [US5] Add unit test: redo after draw undo with SingleLayer payload restores pixels correctly in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T034 [US5] Add unit test: redo after property undo with Property payload restores property value in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T035 [US5] Add unit test: redo after structural undo with FullStack payload restores layer stack in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T036 [US5] Add unit test: new action after undo clears redo stack entirely in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T037 [US5] Add unit test: redo on empty stack returns `DomainError::EmptyHistory` in `src-tauri/src/use_cases/editor_service.rs` tests
+
+### Implementation
+
+- [ ] T038 [US5] Verify `apply_history_swap` redo path pushes correct payload variant for all 3 types — no code change expected if Phase 2 was implemented correctly, but verify with tests in `src-tauri/src/use_cases/editor_service.rs`
+
+**Checkpoint**: Redo works for all payload types. Fork behavior (new action clears redo) works correctly.
+
+---
+
+## Phase 7: User Story 6 — Efficient Undo Capture (Priority: P3)
+
+**Goal**: Undo entries capture only the data modified by the action. Memory is proportional to changes, not total texture size * history depth.
+
+**Independent Test**: Perform 50 paint operations on a 5-layer texture. Verify undo entries contain only the affected layer's data for draws, only metadata for property changes.
+
+### Tests
+
+- [ ] T039 [US6] Add unit test: draw entry on 5-layer texture contains SingleLayer (1 layer snapshot), not 5 layer snapshots — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T040 [US6] Add unit test: property change entry contains no pixel data (PropertyChange variant only) — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T041 [US6] Add unit test: 50 sequential draws on 5-layer texture — total memory of undo entries scales with single-layer size, not 5x — in `src-tauri/src/use_cases/editor_service.rs` tests
+
+### Implementation
+
+- [ ] T042 [US6] No additional code changes expected — efficiency is delivered by the `UndoPayload` architecture from Phase 2 + Phases 3-5. This phase validates the architecture meets memory goals.
+
+**Checkpoint**: Memory efficiency verified. SingleLayer entries are ~1/N the size of FullStack (where N = layer count).
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Edge cases from spec, regression validation, cleanup.
+
+- [ ] T043 Handle edge case: undo history at max capacity evicts oldest entries correctly with mixed payload types in `src-tauri/src/domain/undo.rs` tests
+- [ ] T044 Handle edge case: compound operation — delete layer with painted content produces single FullStack undo entry that restores both layer and content in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T045 Handle edge case: undo layer deletion then continue editing the restored layer — verify subsequent draws create proper SingleLayer entries in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T046 Handle edge case: undo creation of the only remaining layer — verify system follows minimum-layer policy (block undo or restore default empty state) in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T047 Handle edge case: rapid alternation between undo and redo (100+ operations) maintains consistent stacks in `src-tauri/src/use_cases/editor_service.rs` tests
+- [ ] T048 Run full `cargo test` suite in `src-tauri/` to confirm zero regressions
+- [ ] T049 Run quickstart.md validation — execute all 8 test scenarios from `specs/035-fix-undo-redo/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — run immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US1+US2 (Phase 3)**: Depends on Phase 2 — First user-facing increment (MVP)
+- **US3 (Phase 4)**: Depends on Phase 3 (needs SingleLayer payload for stroke finalization)
+- **US4 (Phase 5)**: Depends on Phase 2 only — Can run in parallel with Phase 3
+- **US5 (Phase 6)**: Depends on Phases 3, 4, 5 (needs all payload types implemented to test redo)
+- **US6 (Phase 7)**: Depends on Phases 3, 4, 5 (validates architecture across all payload types)
+- **Polish (Phase 8)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1+US2 (P1)**: Foundational only — can start first
+- **US3 (P2)**: Depends on US1 (needs SingleLayer draw workflow)
+- **US4 (P2)**: Foundational only — can run in parallel with US1+US2
+- **US5 (P2)**: Depends on US1, US3, US4 (tests all payload types)
+- **US6 (P3)**: Depends on US1, US4 (validates memory for draw + property payloads)
+
+### Within Each User Story
+
+- Tests MUST be written first and FAIL before implementation
+- Domain types before use case logic
+- Use case logic before command layer
+- Implementation before regression checks
+- Story complete before moving to dependent stories
+
+### Parallel Opportunities
+
+- T005 + T006 can run in parallel (different files: layer_stack.rs vs editor_service.rs)
+- T009 + T010 can run in parallel (different test files)
+- T026 + T027 can run in parallel (different test functions, same file but independent)
+- **US1+US2 and US4 can run in parallel** after foundational phase (different code paths in editor_service.rs)
+
+---
+
+## Parallel Example: Foundational Phase
+
+```
+# These tasks operate on different files and can run in parallel:
+T005: "Add restore_single_layer to LayerStack in domain/layer_stack.rs"
+T006: "Add property helpers to EditorService in use_cases/editor_service.rs"
+
+# These test tasks can also run in parallel:
+T009: "Update UndoManager tests in domain/undo.rs"
+T010: "Add restore_single_layer tests in domain/layer_stack.rs"
+```
+
+## Parallel Example: After Foundational
+
+```
+# US1+US2 and US4 can proceed in parallel:
+Phase 3 (US1+US2): "Single-layer draw snapshots in editor_service.rs"
+Phase 5 (US4): "Layer operation payloads in editor_service.rs"
+# Note: while both touch editor_service.rs, they modify different methods
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1+US2 Only)
+
+1. Complete Phase 1: Setup (verify baseline)
+2. Complete Phase 2: Foundational (new types, restore logic)
+3. Complete Phase 3: US1+US2 (single-layer draw snapshots)
+4. **STOP and VALIDATE**: Draw strokes, undo/redo, verify correct behavior
+5. Core undo/redo is fixed for the most common operation (painting)
+
+### Incremental Delivery
+
+1. Setup + Foundational → New types ready
+2. US1+US2 → Draw undo works with targeted snapshots → **MVP**
+3. US4 → Layer operations use targeted payloads → Property changes efficient
+4. US3 → Mid-stroke undo works → Edge case resolved
+5. US5 → Redo verified across all types → Full undo/redo correctness
+6. US6 → Memory efficiency validated → Architecture goals met
+7. Polish → Edge cases covered → Production-ready
+
+---
+
+## Notes
+
+- All code changes are in Rust backend only (domain/ and use_cases/)
+- The only command-layer change is in history_commands.rs (T025) for mid-stroke tool cleanup
+- No frontend changes required — existing error handling covers all edge cases
+- No IPC signature changes — all commands keep the same input/output types
+- Constitution Principle IV (Test-First) drives the test-before-implement ordering

--- a/specs/035-fix-undo-redo/tasks.md
+++ b/specs/035-fix-undo-redo/tasks.md
@@ -19,7 +19,7 @@
 
 **Purpose**: No project scaffolding needed — project already exists. Verify baseline.
 
-- [ ] T001 Run `cargo test` in `src-tauri/` to confirm all existing tests pass before changes
+- [x] T001 Run `cargo test` in `src-tauri/` to confirm all existing tests pass before changes
 
 ---
 
@@ -29,15 +29,15 @@
 
 **CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T002 Add `PropertyChange` enum (Opacity, BlendMode, Visibility, Name, Locked) in `src-tauri/src/domain/undo.rs`
-- [ ] T003 Add `UndoPayload` enum (SingleLayer, FullStack, Property) in `src-tauri/src/domain/undo.rs`
-- [ ] T004 Update `UndoEntry` to store `UndoPayload` instead of `TextureSnapshot` — update `new()`, `into_parts()`, accessor methods in `src-tauri/src/domain/undo.rs`
-- [ ] T005 [P] Add `restore_single_layer(LayerSnapshot)` method to `LayerStack` that restores a single layer by ID without replacing the entire stack, in `src-tauri/src/domain/layer_stack.rs`
-- [ ] T006 [P] Add `read_property(layer_id, &PropertyChange) -> PropertyChange` and `apply_property(layer_id, PropertyChange)` helper methods on `EditorService` for symmetric property capture/restore in `src-tauri/src/use_cases/editor_service.rs`
-- [ ] T007 Add `pending_draw_layer_id: Option<LayerId>` field to `EditorService` struct, initialize to `None` in constructors, in `src-tauri/src/use_cases/editor_service.rs`
-- [ ] T008 Rewrite `apply_history_swap` to match on `UndoPayload` variant — SingleLayer: capture/restore single layer; FullStack: capture/restore all layers (existing behavior); Property: read/set property value — in `src-tauri/src/use_cases/editor_service.rs`
-- [ ] T009 Update existing `UndoManager` tests in `src-tauri/src/domain/undo.rs` to use `UndoEntry::new(op, UndoPayload::FullStack(...))` instead of `UndoEntry::new(op, TextureSnapshot)`
-- [ ] T010 [P] Add unit tests for `LayerStack::restore_single_layer` — restore preserves other layers, error on unknown ID — in `src-tauri/src/domain/layer_stack.rs`
+- [x] T002 Add `PropertyChange` enum (Opacity, BlendMode, Visibility, Name, Locked) in `src-tauri/src/domain/undo.rs`
+- [x] T003 Add `UndoPayload` enum (SingleLayer, FullStack, Property) in `src-tauri/src/domain/undo.rs`
+- [x] T004 Update `UndoEntry` to store `UndoPayload` instead of `TextureSnapshot` — update `new()`, `into_parts()`, accessor methods in `src-tauri/src/domain/undo.rs`
+- [x] T005 [P] Add `restore_single_layer(LayerSnapshot)` method to `LayerStack` that restores a single layer by ID without replacing the entire stack, in `src-tauri/src/domain/layer_stack.rs`
+- [x] T006 [P] Add `read_property(layer_id, &PropertyChange) -> PropertyChange` and `apply_property(layer_id, PropertyChange)` helper methods on `EditorService` for symmetric property capture/restore in `src-tauri/src/use_cases/editor_service.rs`
+- [x] T007 Add `pending_draw_layer_id: Option<LayerId>` field to `EditorService` struct, initialize to `None` in constructors, in `src-tauri/src/use_cases/editor_service.rs`
+- [x] T008 Rewrite `apply_history_swap` to match on `UndoPayload` variant — SingleLayer: capture/restore single layer; FullStack: capture/restore all layers (existing behavior); Property: read/set property value — in `src-tauri/src/use_cases/editor_service.rs`
+- [x] T009 Update existing `UndoManager` tests in `src-tauri/src/domain/undo.rs` to use `UndoEntry::new(op, UndoPayload::FullStack(...))` instead of `UndoEntry::new(op, TextureSnapshot)`
+- [x] T010 [P] Add unit tests for `LayerStack::restore_single_layer` — restore preserves other layers, error on unknown ID — in `src-tauri/src/domain/layer_stack.rs`
 
 **Checkpoint**: New types compile. `apply_history_swap` handles all 3 payload variants. All existing tests updated and passing.
 
@@ -51,18 +51,18 @@
 
 ### Tests
 
-- [ ] T011 [US1] Add unit test: single brush stroke produces `UndoPayload::SingleLayer` entry (not FullStack) in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T012 [US1] Add unit test: undo single stroke restores pixels to pre-stroke state in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T013 [US1] Add unit test: three strokes → three undos → each reverts one stroke in reverse order in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T014 [US2] Add unit test: multiple back-to-back strokes (no delay) produce separate undo entries in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T015 [US1] Add unit test: undo on empty history returns `DomainError::EmptyHistory` (existing test, verify still passes) in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T011 [US1] Add unit test: single brush stroke produces `UndoPayload::SingleLayer` entry (not FullStack) in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T012 [US1] Add unit test: undo single stroke restores pixels to pre-stroke state in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T013 [US1] Add unit test: three strokes → three undos → each reverts one stroke in reverse order in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T014 [US2] Add unit test: multiple back-to-back strokes (no delay) produce separate undo entries in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T015 [US1] Add unit test: undo on empty history returns `DomainError::EmptyHistory` (existing test, verify still passes) in `src-tauri/src/use_cases/editor_service.rs` tests
 
 ### Implementation
 
-- [ ] T016 [US1] Update `apply_tool_press` to set `pending_draw_layer_id = Some(layer_id)` in `src-tauri/src/use_cases/editor_service.rs`
-- [ ] T017 [US1] Update `apply_tool_release` to extract the affected layer from `pending_snapshot` as `UndoPayload::SingleLayer(layer_snapshot)` using `pending_draw_layer_id`, then push to undo manager, in `src-tauri/src/use_cases/editor_service.rs`
-- [ ] T018 [US1] Clear `pending_draw_layer_id` in `apply_tool_release` (both success and no-modification paths) in `src-tauri/src/use_cases/editor_service.rs`
-- [ ] T019 [US1] Verify all existing `editor_service` stroke tests pass with the new SingleLayer payload — fix any assertion that inspects snapshot internals in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T016 [US1] Update `apply_tool_press` to set `pending_draw_layer_id = Some(layer_id)` in `src-tauri/src/use_cases/editor_service.rs`
+- [x] T017 [US1] Update `apply_tool_release` to extract the affected layer from `pending_snapshot` as `UndoPayload::SingleLayer(layer_snapshot)` using `pending_draw_layer_id`, then push to undo manager, in `src-tauri/src/use_cases/editor_service.rs`
+- [x] T018 [US1] Clear `pending_draw_layer_id` in `apply_tool_release` (both success and no-modification paths) in `src-tauri/src/use_cases/editor_service.rs`
+- [x] T019 [US1] Verify all existing `editor_service` stroke tests pass with the new SingleLayer payload — fix any assertion that inspects snapshot internals in `src-tauri/src/use_cases/editor_service.rs` tests
 
 **Checkpoint**: All stroke-level undo tests pass. Each stroke produces a SingleLayer payload. Rapid strokes produce separate entries.
 
@@ -76,15 +76,15 @@
 
 ### Tests
 
-- [ ] T020 [US3] Add unit test: undo during active stroke with pixels modified — finalizes as entry then undoes it, canvas returns to pre-stroke state — in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T021 [US3] Add unit test: undo during active stroke with NO pixels modified — discards pending, undoes previous action — in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T022 [US3] Add unit test: redo after mid-stroke undo restores the cancelled stroke — in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T023 [US3] Add unit test: subsequent undo/redo operations remain consistent after mid-stroke undo — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T020 [US3] Add unit test: undo during active stroke with pixels modified — finalizes as entry then undoes it, canvas returns to pre-stroke state — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T021 [US3] Add unit test: undo during active stroke with NO pixels modified — discards pending, undoes previous action — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T022 [US3] Add unit test: redo after mid-stroke undo restores the cancelled stroke — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T023 [US3] Add unit test: subsequent undo/redo operations remain consistent after mid-stroke undo — in `src-tauri/src/use_cases/editor_service.rs` tests
 
 ### Implementation
 
-- [ ] T024 [US3] Add mid-stroke finalization logic at the start of `EditorService::undo()` — if `pending_snapshot.is_some()`, finalize the stroke (push SingleLayer entry if pixels modified, clear pending state), then proceed with normal undo — in `src-tauri/src/use_cases/editor_service.rs`
-- [ ] T025 [US3] In `undo` command in `src-tauri/src/commands/history_commands.rs`, after undo completes, check if `active_tool` exists and clear it (`state.active_tool = None`) to signal stroke cancellation
+- [x] T024 [US3] Add mid-stroke finalization logic at the start of `EditorService::undo()` — if `pending_snapshot.is_some()`, finalize the stroke (push SingleLayer entry if pixels modified, clear pending state), then proceed with normal undo — in `src-tauri/src/use_cases/editor_service.rs`
+- [x] T025 [US3] In `undo` command in `src-tauri/src/commands/history_commands.rs`, after undo completes, check if `active_tool` exists and clear it (`state.active_tool = None`) to signal stroke cancellation
 
 **Checkpoint**: Mid-stroke undo works correctly. Tool state is cleaned up. Redo after mid-stroke undo restores the stroke.
 
@@ -98,16 +98,16 @@
 
 ### Tests
 
-- [ ] T026 [P] [US4] Add unit tests for each layer property: set_opacity, set_blend_mode, set_visibility, set_name, set_locked each produce `UndoPayload::Property` with the correct old value — in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T027 [P] [US4] Add unit tests: add_layer and remove_layer produce `UndoPayload::FullStack` — in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T028 [US4] Add unit test: undo layer rename reverts name, undo layer opacity reverts value, undo layer add removes the layer — in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T029 [US4] Add unit test: mixed draw + layer operations undo in correct reverse order — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T026 [P] [US4] Add unit tests for each layer property: set_opacity, set_blend_mode, set_visibility, set_name, set_locked each produce `UndoPayload::Property` with the correct old value — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T027 [P] [US4] Add unit tests: add_layer and remove_layer produce `UndoPayload::FullStack` — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T028 [US4] Add unit test: undo layer rename reverts name, undo layer opacity reverts value, undo layer add removes the layer — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T029 [US4] Add unit test: mixed draw + layer operations undo in correct reverse order — in `src-tauri/src/use_cases/editor_service.rs` tests
 
 ### Implementation
 
-- [ ] T030 [US4] Update `with_layer_undo` to capture `PropertyChange` from the layer's current state before mutation and push `UndoPayload::Property { layer_id, change }` in `src-tauri/src/use_cases/editor_service.rs`
-- [ ] T031 [US4] Update `add_layer`, `add_layer_above`, `duplicate_layer`, `remove_layer`, `move_layer` to push `UndoPayload::FullStack(TextureSnapshot::capture(...))` explicitly in `src-tauri/src/use_cases/editor_service.rs`
-- [ ] T032 [US4] Update existing layer operation tests to account for new payload types in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T030 [US4] Update `with_layer_undo` to capture `PropertyChange` from the layer's current state before mutation and push `UndoPayload::Property { layer_id, change }` in `src-tauri/src/use_cases/editor_service.rs`
+- [x] T031 [US4] Update `add_layer`, `add_layer_above`, `duplicate_layer`, `remove_layer`, `move_layer` to push `UndoPayload::FullStack(TextureSnapshot::capture(...))` explicitly in `src-tauri/src/use_cases/editor_service.rs`
+- [x] T032 [US4] Update existing layer operation tests to account for new payload types in `src-tauri/src/use_cases/editor_service.rs` tests
 
 **Checkpoint**: All layer operations are individually undoable. Property changes store metadata only. Structural changes store full stack.
 
@@ -121,15 +121,15 @@
 
 ### Tests
 
-- [ ] T033 [US5] Add unit test: redo after draw undo with SingleLayer payload restores pixels correctly in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T034 [US5] Add unit test: redo after property undo with Property payload restores property value in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T035 [US5] Add unit test: redo after structural undo with FullStack payload restores layer stack in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T036 [US5] Add unit test: new action after undo clears redo stack entirely in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T037 [US5] Add unit test: redo on empty stack returns `DomainError::EmptyHistory` in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T033 [US5] Add unit test: redo after draw undo with SingleLayer payload restores pixels correctly in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T034 [US5] Add unit test: redo after property undo with Property payload restores property value in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T035 [US5] Add unit test: redo after structural undo with FullStack payload restores layer stack in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T036 [US5] Add unit test: new action after undo clears redo stack entirely in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T037 [US5] Add unit test: redo on empty stack returns `DomainError::EmptyHistory` in `src-tauri/src/use_cases/editor_service.rs` tests
 
 ### Implementation
 
-- [ ] T038 [US5] Verify `apply_history_swap` redo path pushes correct payload variant for all 3 types — no code change expected if Phase 2 was implemented correctly, but verify with tests in `src-tauri/src/use_cases/editor_service.rs`
+- [x] T038 [US5] Verify `apply_history_swap` redo path pushes correct payload variant for all 3 types — no code change expected if Phase 2 was implemented correctly, but verify with tests in `src-tauri/src/use_cases/editor_service.rs`
 
 **Checkpoint**: Redo works for all payload types. Fork behavior (new action clears redo) works correctly.
 
@@ -143,13 +143,13 @@
 
 ### Tests
 
-- [ ] T039 [US6] Add unit test: draw entry on 5-layer texture contains SingleLayer (1 layer snapshot), not 5 layer snapshots — in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T040 [US6] Add unit test: property change entry contains no pixel data (PropertyChange variant only) — in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T041 [US6] Add unit test: 50 sequential draws on 5-layer texture — total memory of undo entries scales with single-layer size, not 5x — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T039 [US6] Add unit test: draw entry on 5-layer texture contains SingleLayer (1 layer snapshot), not 5 layer snapshots — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T040 [US6] Add unit test: property change entry contains no pixel data (PropertyChange variant only) — in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T041 [US6] Add unit test: 50 sequential draws on 5-layer texture — total memory of undo entries scales with single-layer size, not 5x — in `src-tauri/src/use_cases/editor_service.rs` tests
 
 ### Implementation
 
-- [ ] T042 [US6] No additional code changes expected — efficiency is delivered by the `UndoPayload` architecture from Phase 2 + Phases 3-5. This phase validates the architecture meets memory goals.
+- [x] T042 [US6] No additional code changes expected — efficiency is delivered by the `UndoPayload` architecture from Phase 2 + Phases 3-5. This phase validates the architecture meets memory goals.
 
 **Checkpoint**: Memory efficiency verified. SingleLayer entries are ~1/N the size of FullStack (where N = layer count).
 
@@ -159,13 +159,13 @@
 
 **Purpose**: Edge cases from spec, regression validation, cleanup.
 
-- [ ] T043 Handle edge case: undo history at max capacity evicts oldest entries correctly with mixed payload types in `src-tauri/src/domain/undo.rs` tests
-- [ ] T044 Handle edge case: compound operation — delete layer with painted content produces single FullStack undo entry that restores both layer and content in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T045 Handle edge case: undo layer deletion then continue editing the restored layer — verify subsequent draws create proper SingleLayer entries in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T046 Handle edge case: undo creation of the only remaining layer — verify system follows minimum-layer policy (block undo or restore default empty state) in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T047 Handle edge case: rapid alternation between undo and redo (100+ operations) maintains consistent stacks in `src-tauri/src/use_cases/editor_service.rs` tests
-- [ ] T048 Run full `cargo test` suite in `src-tauri/` to confirm zero regressions
-- [ ] T049 Run quickstart.md validation — execute all 8 test scenarios from `specs/035-fix-undo-redo/quickstart.md`
+- [x] T043 Handle edge case: undo history at max capacity evicts oldest entries correctly with mixed payload types in `src-tauri/src/domain/undo.rs` tests
+- [x] T044 Handle edge case: compound operation — delete layer with painted content produces single FullStack undo entry that restores both layer and content in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T045 Handle edge case: undo layer deletion then continue editing the restored layer — verify subsequent draws create proper SingleLayer entries in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T046 Handle edge case: undo creation of the only remaining layer — verify system follows minimum-layer policy (block undo or restore default empty state) in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T047 Handle edge case: rapid alternation between undo and redo (100+ operations) maintains consistent stacks in `src-tauri/src/use_cases/editor_service.rs` tests
+- [x] T048 Run full `cargo test` suite in `src-tauri/` to confirm zero regressions
+- [x] T049 Run quickstart.md validation — execute all 8 test scenarios from `specs/035-fix-undo-redo/quickstart.md`
 
 ---
 

--- a/src-tauri/src/commands/history_commands.rs
+++ b/src-tauri/src/commands/history_commands.rs
@@ -13,7 +13,11 @@ pub fn undo(app: AppHandle, state: State<'_, Mutex<AppState>>) -> Result<EditorS
         .lock()
         .map_err(|_| AppError::Internal("state lock poisoned".into()))?;
 
-    state.editor_mut()?.undo()?;
+    let was_mid_stroke = state.editor_mut()?.undo()?;
+    if was_mid_stroke {
+        state.active_tool = None;
+    }
+
     let dto = build_editor_state_dto(state.editor.as_ref(), state.active_layer_id);
 
     emit_state_changed(&app);

--- a/src-tauri/src/domain/layer_stack.rs
+++ b/src-tauri/src/domain/layer_stack.rs
@@ -2,7 +2,7 @@ use super::blend;
 use super::error::DomainError;
 use super::layer::{Layer, LayerId};
 use super::pixel_buffer::PixelBuffer;
-use super::undo::TextureSnapshot;
+use super::undo::{LayerSnapshot, TextureSnapshot};
 
 /// Ordered collection of layers (bottom to top).
 /// Manages layer lifecycle and compositing.
@@ -77,6 +77,17 @@ impl LayerStack {
         &self.layers
     }
 
+    /// Restores a single layer by ID from its snapshot, preserving all other layers.
+    pub fn restore_single_layer(&mut self, snapshot: LayerSnapshot) -> Result<(), DomainError> {
+        let layer = self
+            .get_layer_mut(snapshot.id)
+            .ok_or(DomainError::LayerNotFound {
+                layer_id: snapshot.id.value(),
+            })?;
+        layer.restore_from_snapshot(snapshot)?;
+        Ok(())
+    }
+
     /// Replaces all layers from the given texture snapshot.
     pub fn restore_from_snapshots(&mut self, snapshot: TextureSnapshot) -> Result<(), DomainError> {
         let mut new_layers = Vec::with_capacity(snapshot.layers.len());
@@ -132,6 +143,7 @@ mod tests {
     use super::*;
     use crate::domain::blend::BlendMode;
     use crate::domain::color::Color;
+    use crate::domain::undo::LayerSnapshot;
 
     fn make_layer(id: u128, name: &str, w: u32, h: u32) -> Layer {
         Layer::new(LayerId::new(id), name.to_string(), w, h).unwrap()
@@ -435,6 +447,67 @@ mod tests {
     fn index_of_missing_layer() {
         let stack = LayerStack::new();
         assert_eq!(stack.index_of(LayerId::new(99)), None);
+    }
+
+    #[test]
+    fn restore_single_layer_preserves_other_layers() {
+        let mut stack = LayerStack::new();
+        let red = Color::new(255, 0, 0, 255);
+        let blue = Color::new(0, 0, 255, 255);
+
+        let mut layer1 = make_layer(1, "a", 2, 2);
+        layer1.set_pixel(0, 0, red).unwrap();
+        stack.add_layer(layer1);
+
+        let mut layer2 = make_layer(2, "b", 2, 2);
+        layer2.set_pixel(0, 0, blue).unwrap();
+        stack.add_layer(layer2);
+
+        // Snapshot layer 1 before modification
+        let snapshot = LayerSnapshot::from_layer(stack.get_layer(LayerId::new(1)).unwrap());
+
+        // Modify layer 1
+        stack
+            .get_layer_mut(LayerId::new(1))
+            .unwrap()
+            .set_pixel(0, 0, Color::WHITE)
+            .unwrap();
+
+        // Restore layer 1
+        stack.restore_single_layer(snapshot).unwrap();
+
+        // Layer 1 restored
+        assert_eq!(
+            stack
+                .get_layer(LayerId::new(1))
+                .unwrap()
+                .buffer()
+                .get_pixel(0, 0)
+                .unwrap(),
+            red
+        );
+        // Layer 2 untouched
+        assert_eq!(
+            stack
+                .get_layer(LayerId::new(2))
+                .unwrap()
+                .buffer()
+                .get_pixel(0, 0)
+                .unwrap(),
+            blue
+        );
+    }
+
+    #[test]
+    fn restore_single_layer_unknown_id_returns_error() {
+        let mut stack = LayerStack::new();
+        stack.add_layer(make_layer(1, "a", 2, 2));
+
+        let snapshot = LayerSnapshot::from_layer(stack.get_layer(LayerId::new(1)).unwrap());
+        stack.remove_layer(LayerId::new(1)).unwrap();
+
+        let err = stack.restore_single_layer(snapshot).unwrap_err();
+        assert_eq!(err, DomainError::LayerNotFound { layer_id: 1 });
     }
 
     #[test]

--- a/src-tauri/src/domain/undo.rs
+++ b/src-tauri/src/domain/undo.rs
@@ -62,27 +62,74 @@ pub enum OperationType {
     LayerPropertyChange,
 }
 
+/// Identifies which property of a layer is being changed (discriminant only, no value).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PropertyKind {
+    Opacity,
+    BlendMode,
+    Visibility,
+    Name,
+    Locked,
+}
+
+/// The old value of a single layer property, used for metadata-only undo.
+#[derive(Debug)]
+pub enum PropertyChange {
+    Opacity(f32),
+    BlendMode(BlendMode),
+    Visibility(bool),
+    Name(String),
+    Locked(bool),
+}
+
+impl PropertyChange {
+    pub fn kind(&self) -> PropertyKind {
+        match self {
+            Self::Opacity(_) => PropertyKind::Opacity,
+            Self::BlendMode(_) => PropertyKind::BlendMode,
+            Self::Visibility(_) => PropertyKind::Visibility,
+            Self::Name(_) => PropertyKind::Name,
+            Self::Locked(_) => PropertyKind::Locked,
+        }
+    }
+}
+
+/// Discriminated payload representing the minimum data needed to reverse an operation.
+#[derive(Debug)]
+pub enum UndoPayload {
+    /// Full pixel snapshot of a single affected layer (for draw operations).
+    SingleLayer(LayerSnapshot),
+    /// Full layer stack snapshot (for structural changes: add, remove, reorder).
+    FullStack(TextureSnapshot),
+    /// Metadata-only snapshot for a single layer property change.
+    Property {
+        layer_id: LayerId,
+        change: PropertyChange,
+    },
+}
+
 /// A single undoable step. Captures the state *before* the operation.
 #[derive(Debug)]
 pub struct UndoEntry {
     operation: OperationType,
-    snapshot: TextureSnapshot,
+    payload: UndoPayload,
 }
 
 impl UndoEntry {
-    pub fn new(operation: OperationType, snapshot: TextureSnapshot) -> Self {
-        Self {
-            operation,
-            snapshot,
-        }
+    pub(crate) fn new(operation: OperationType, payload: UndoPayload) -> Self {
+        Self { operation, payload }
     }
 
     pub fn operation(&self) -> &OperationType {
         &self.operation
     }
 
-    pub fn into_parts(self) -> (OperationType, TextureSnapshot) {
-        (self.operation, self.snapshot)
+    pub fn payload(&self) -> &UndoPayload {
+        &self.payload
+    }
+
+    pub fn into_parts(self) -> (OperationType, UndoPayload) {
+        (self.operation, self.payload)
     }
 }
 
@@ -124,6 +171,11 @@ impl UndoManager {
 
     pub(crate) fn pop_undo(&mut self) -> Option<UndoEntry> {
         self.undo_stack.pop_back()
+    }
+
+    /// Peeks at the most recent undo entry without removing it.
+    pub fn peek_undo(&self) -> Option<&UndoEntry> {
+        self.undo_stack.back()
     }
 
     pub(crate) fn push_redo(&mut self, entry: UndoEntry) {
@@ -182,7 +234,7 @@ mod tests {
     }
 
     fn make_entry(op: OperationType) -> UndoEntry {
-        UndoEntry::new(op, make_snapshot(1))
+        UndoEntry::new(op, UndoPayload::FullStack(make_snapshot(1)))
     }
 
     // --- Snapshot round-trip tests (T007) ---

--- a/src-tauri/src/use_cases/editor_service.rs
+++ b/src-tauri/src/use_cases/editor_service.rs
@@ -6,7 +6,10 @@ use crate::domain::pixel_buffer::PixelBuffer;
 use crate::domain::ports::ImageWriter;
 use crate::domain::texture::Texture;
 use crate::domain::tools::{BrushSize, Tool, ToolContext, ToolResult};
-use crate::domain::undo::{OperationType, TextureSnapshot, UndoEntry, UndoManager};
+use crate::domain::undo::{
+    LayerSnapshot, OperationType, PropertyChange, PropertyKind, TextureSnapshot, UndoEntry,
+    UndoManager, UndoPayload,
+};
 
 const DEFAULT_MAX_HISTORY: usize = 100;
 
@@ -20,7 +23,9 @@ enum ToolPhase {
 pub struct EditorService {
     texture: Texture,
     undo_manager: UndoManager,
-    pending_snapshot: Option<TextureSnapshot>,
+    /// Snapshot of the single affected layer captured at stroke press time.
+    /// Used at release (or mid-stroke undo) to build the SingleLayer undo entry.
+    pending_layer_snapshot: Option<LayerSnapshot>,
     pixels_modified_in_cycle: bool,
 }
 
@@ -33,9 +38,14 @@ impl EditorService {
         Self {
             texture,
             undo_manager: UndoManager::new(max_depth),
-            pending_snapshot: None,
+            pending_layer_snapshot: None,
             pixels_modified_in_cycle: false,
         }
+    }
+
+    /// Returns whether a stroke is currently in progress.
+    pub fn has_pending_stroke(&self) -> bool {
+        self.pending_layer_snapshot.is_some()
     }
 
     pub fn texture(&self) -> &Texture {
@@ -54,6 +64,11 @@ impl EditorService {
 
     pub fn can_redo(&self) -> bool {
         self.undo_manager.can_redo()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn undo_manager(&self) -> &UndoManager {
+        &self.undo_manager
     }
 
     // -- Factory methods --
@@ -165,9 +180,16 @@ impl EditorService {
         brush_size: BrushSize,
         opacity: f32,
     ) -> Result<ToolResult, DomainError> {
-        self.pending_snapshot = Some(TextureSnapshot::capture(self.texture.layer_stack()));
+        let layer =
+            self.texture
+                .layer_stack()
+                .get_layer(layer_id)
+                .ok_or(DomainError::LayerNotFound {
+                    layer_id: layer_id.value(),
+                })?;
+        self.pending_layer_snapshot = Some(LayerSnapshot::from_layer(layer));
         self.pixels_modified_in_cycle = false;
-        self.run_tool(
+        let result = self.run_tool(
             tool,
             ToolPhase::Press,
             layer_id,
@@ -176,7 +198,11 @@ impl EditorService {
             color,
             brush_size,
             opacity,
-        )
+        );
+        if result.is_err() {
+            self.pending_layer_snapshot = None;
+        }
+        result
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -224,20 +250,69 @@ impl EditorService {
             opacity,
         )?;
         if self.pixels_modified_in_cycle {
-            if let Some(snapshot) = self.pending_snapshot.take() {
-                self.undo_manager
-                    .push(UndoEntry::new(OperationType::Draw, snapshot));
+            if let Some(layer_snapshot) = self.pending_layer_snapshot.take() {
+                self.undo_manager.push(UndoEntry::new(
+                    OperationType::Draw,
+                    UndoPayload::SingleLayer(layer_snapshot),
+                ));
             }
         } else {
-            self.pending_snapshot = None;
+            self.pending_layer_snapshot = None;
         }
         Ok(result)
+    }
+
+    // -- Property helpers --
+
+    /// Reads the current value of a layer property identified by kind.
+    fn read_property(
+        &self,
+        layer_id: LayerId,
+        kind: PropertyKind,
+    ) -> Result<PropertyChange, DomainError> {
+        let layer =
+            self.texture
+                .layer_stack()
+                .get_layer(layer_id)
+                .ok_or(DomainError::LayerNotFound {
+                    layer_id: layer_id.value(),
+                })?;
+        Ok(match kind {
+            PropertyKind::Opacity => PropertyChange::Opacity(layer.opacity()),
+            PropertyKind::BlendMode => PropertyChange::BlendMode(layer.blend_mode()),
+            PropertyKind::Visibility => PropertyChange::Visibility(layer.is_visible()),
+            PropertyKind::Name => PropertyChange::Name(layer.name().to_string()),
+            PropertyKind::Locked => PropertyChange::Locked(layer.is_locked()),
+        })
+    }
+
+    /// Applies a property change to a layer.
+    fn apply_property(
+        &mut self,
+        layer_id: LayerId,
+        change: PropertyChange,
+    ) -> Result<(), DomainError> {
+        let layer = self
+            .texture
+            .layer_stack_mut()
+            .get_layer_mut(layer_id)
+            .ok_or(DomainError::LayerNotFound {
+                layer_id: layer_id.value(),
+            })?;
+        match change {
+            PropertyChange::Opacity(v) => layer.set_opacity(v),
+            PropertyChange::BlendMode(m) => layer.set_blend_mode(m),
+            PropertyChange::Visibility(v) => layer.set_visible(v),
+            PropertyChange::Name(n) => layer.set_name(n)?,
+            PropertyChange::Locked(v) => layer.set_locked(v),
+        }
+        Ok(())
     }
 
     // -- Undo/Redo --
 
     /// Generic undo/redo swap: pops an entry from one stack, captures the current
-    /// state as the reverse entry, restores the popped snapshot, then pushes the
+    /// state as the reverse entry, restores from the popped payload, then pushes the
     /// captured state onto the opposite stack.
     fn apply_history_swap(
         &mut self,
@@ -245,18 +320,65 @@ impl EditorService {
         push: fn(&mut UndoManager, UndoEntry),
     ) -> Result<(), DomainError> {
         let entry = pop(&mut self.undo_manager).ok_or(DomainError::EmptyHistory)?;
-        let (operation, snapshot) = entry.into_parts();
-        let current = TextureSnapshot::capture(self.texture.layer_stack());
-        self.texture
-            .layer_stack_mut()
-            .restore_from_snapshots(snapshot)?;
-        push(&mut self.undo_manager, UndoEntry::new(operation, current));
+        let (operation, payload) = entry.into_parts();
+
+        let reverse_payload = match payload {
+            UndoPayload::SingleLayer(old_layer) => {
+                let current_layer = LayerSnapshot::from_layer(
+                    self.texture.layer_stack().get_layer(old_layer.id).ok_or(
+                        DomainError::LayerNotFound {
+                            layer_id: old_layer.id.value(),
+                        },
+                    )?,
+                );
+                self.texture
+                    .layer_stack_mut()
+                    .restore_single_layer(old_layer)?;
+                UndoPayload::SingleLayer(current_layer)
+            }
+            UndoPayload::FullStack(old_texture) => {
+                let current = TextureSnapshot::capture(self.texture.layer_stack());
+                self.texture
+                    .layer_stack_mut()
+                    .restore_from_snapshots(old_texture)?;
+                UndoPayload::FullStack(current)
+            }
+            UndoPayload::Property { layer_id, change } => {
+                let current_value = self.read_property(layer_id, change.kind())?;
+                self.apply_property(layer_id, change)?;
+                UndoPayload::Property {
+                    layer_id,
+                    change: current_value,
+                }
+            }
+        };
+
+        push(
+            &mut self.undo_manager,
+            UndoEntry::new(operation, reverse_payload),
+        );
         self.texture.mark_dirty();
         Ok(())
     }
 
-    pub fn undo(&mut self) -> Result<(), DomainError> {
-        self.apply_history_swap(UndoManager::pop_undo, UndoManager::push_redo)
+    /// Undoes the last operation. If a stroke is in progress (mid-stroke undo),
+    /// finalizes it first, then undoes it. Returns whether a stroke was cancelled.
+    pub fn undo(&mut self) -> Result<bool, DomainError> {
+        let was_mid_stroke = self.pending_layer_snapshot.is_some();
+
+        // Mid-stroke finalization: if a stroke is in progress, finalize it first
+        if let Some(layer_snapshot) = self.pending_layer_snapshot.take() {
+            if self.pixels_modified_in_cycle {
+                self.undo_manager.push(UndoEntry::new(
+                    OperationType::Draw,
+                    UndoPayload::SingleLayer(layer_snapshot),
+                ));
+            }
+            self.pixels_modified_in_cycle = false;
+        }
+
+        self.apply_history_swap(UndoManager::pop_undo, UndoManager::push_redo)?;
+        Ok(was_mid_stroke)
     }
 
     pub fn redo(&mut self) -> Result<(), DomainError> {
@@ -268,8 +390,10 @@ impl EditorService {
     pub fn add_layer(&mut self, id: LayerId, name: &str) -> Result<(), DomainError> {
         let snapshot = TextureSnapshot::capture(self.texture.layer_stack());
         self.texture.add_layer(id, name.to_string())?;
-        self.undo_manager
-            .push(UndoEntry::new(OperationType::LayerAdd, snapshot));
+        self.undo_manager.push(UndoEntry::new(
+            OperationType::LayerAdd,
+            UndoPayload::FullStack(snapshot),
+        ));
         Ok(())
     }
 
@@ -303,8 +427,10 @@ impl EditorService {
             }
         }
         self.texture.mark_dirty();
-        self.undo_manager
-            .push(UndoEntry::new(OperationType::LayerAdd, snapshot));
+        self.undo_manager.push(UndoEntry::new(
+            OperationType::LayerAdd,
+            UndoPayload::FullStack(snapshot),
+        ));
         Ok(())
     }
 
@@ -327,8 +453,10 @@ impl EditorService {
             .layer_stack_mut()
             .insert_layer(index + 1, duplicate)?;
         self.texture.mark_dirty();
-        self.undo_manager
-            .push(UndoEntry::new(OperationType::LayerAdd, snapshot));
+        self.undo_manager.push(UndoEntry::new(
+            OperationType::LayerAdd,
+            UndoPayload::FullStack(snapshot),
+        ));
         Ok(())
     }
 
@@ -336,8 +464,10 @@ impl EditorService {
         let snapshot = TextureSnapshot::capture(self.texture.layer_stack());
         self.texture.layer_stack_mut().remove_layer(id)?;
         self.texture.mark_dirty();
-        self.undo_manager
-            .push(UndoEntry::new(OperationType::LayerRemove, snapshot));
+        self.undo_manager.push(UndoEntry::new(
+            OperationType::LayerRemove,
+            UndoPayload::FullStack(snapshot),
+        ));
         Ok(())
     }
 
@@ -347,18 +477,19 @@ impl EditorService {
             .layer_stack_mut()
             .move_layer(from_index, to_index)?;
         self.texture.mark_dirty();
-        self.undo_manager
-            .push(UndoEntry::new(OperationType::LayerReorder, snapshot));
+        self.undo_manager.push(UndoEntry::new(
+            OperationType::LayerReorder,
+            UndoPayload::FullStack(snapshot),
+        ));
         Ok(())
     }
 
-    fn with_layer_undo(
+    fn with_property_undo(
         &mut self,
         id: LayerId,
-        op: OperationType,
+        old_value: PropertyChange,
         f: impl FnOnce(&mut Layer) -> Result<(), DomainError>,
     ) -> Result<(), DomainError> {
-        let snapshot = TextureSnapshot::capture(self.texture.layer_stack());
         let layer =
             self.texture
                 .layer_stack_mut()
@@ -368,12 +499,26 @@ impl EditorService {
                 })?;
         f(layer)?;
         self.texture.mark_dirty();
-        self.undo_manager.push(UndoEntry::new(op, snapshot));
+        self.undo_manager.push(UndoEntry::new(
+            OperationType::LayerPropertyChange,
+            UndoPayload::Property {
+                layer_id: id,
+                change: old_value,
+            },
+        ));
         Ok(())
     }
 
     pub fn set_layer_opacity(&mut self, id: LayerId, opacity: f32) -> Result<(), DomainError> {
-        self.with_layer_undo(id, OperationType::LayerPropertyChange, |layer| {
+        let old = self
+            .texture
+            .layer_stack()
+            .get_layer(id)
+            .ok_or(DomainError::LayerNotFound {
+                layer_id: id.value(),
+            })?
+            .opacity();
+        self.with_property_undo(id, PropertyChange::Opacity(old), |layer| {
             layer.set_opacity(opacity);
             Ok(())
         })
@@ -384,28 +529,61 @@ impl EditorService {
         id: LayerId,
         mode: BlendMode,
     ) -> Result<(), DomainError> {
-        self.with_layer_undo(id, OperationType::LayerPropertyChange, |layer| {
+        let old = self
+            .texture
+            .layer_stack()
+            .get_layer(id)
+            .ok_or(DomainError::LayerNotFound {
+                layer_id: id.value(),
+            })?
+            .blend_mode();
+        self.with_property_undo(id, PropertyChange::BlendMode(old), |layer| {
             layer.set_blend_mode(mode);
             Ok(())
         })
     }
 
     pub fn set_layer_visibility(&mut self, id: LayerId, visible: bool) -> Result<(), DomainError> {
-        self.with_layer_undo(id, OperationType::LayerPropertyChange, |layer| {
+        let old = self
+            .texture
+            .layer_stack()
+            .get_layer(id)
+            .ok_or(DomainError::LayerNotFound {
+                layer_id: id.value(),
+            })?
+            .is_visible();
+        self.with_property_undo(id, PropertyChange::Visibility(old), |layer| {
             layer.set_visible(visible);
             Ok(())
         })
     }
 
     pub fn set_layer_name(&mut self, id: LayerId, name: &str) -> Result<(), DomainError> {
-        let name = name.to_string();
-        self.with_layer_undo(id, OperationType::LayerPropertyChange, move |layer| {
-            layer.set_name(name)
+        let old = self
+            .texture
+            .layer_stack()
+            .get_layer(id)
+            .ok_or(DomainError::LayerNotFound {
+                layer_id: id.value(),
+            })?
+            .name()
+            .to_string();
+        let new_name = name.to_string();
+        self.with_property_undo(id, PropertyChange::Name(old), move |layer| {
+            layer.set_name(new_name)
         })
     }
 
     pub fn set_layer_locked(&mut self, id: LayerId, locked: bool) -> Result<(), DomainError> {
-        self.with_layer_undo(id, OperationType::LayerPropertyChange, |layer| {
+        let old = self
+            .texture
+            .layer_stack()
+            .get_layer(id)
+            .ok_or(DomainError::LayerNotFound {
+                layer_id: id.value(),
+            })?
+            .is_locked();
+        self.with_property_undo(id, PropertyChange::Locked(old), |layer| {
             layer.set_locked(locked);
             Ok(())
         })
@@ -1471,5 +1649,706 @@ mod tests {
             .get_layer(LayerId::new(2))
             .unwrap();
         assert!(!dup.is_locked(), "duplicated layer must be unlocked");
+    }
+
+    // === Phase 3: T011-T014 — SingleLayer payload for draw strokes ===
+
+    #[test]
+    fn t011_brush_stroke_produces_single_layer_payload() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let mut tool = BrushTool::default();
+
+        brush_stroke(&mut svc, &mut tool, id, 0, 0, Color::WHITE);
+
+        let entry = svc.undo_manager().peek_undo().unwrap();
+        assert!(
+            matches!(entry.payload(), UndoPayload::SingleLayer(_)),
+            "draw stroke must produce SingleLayer payload"
+        );
+    }
+
+    #[test]
+    fn t012_undo_single_stroke_restores_pre_stroke_pixels() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let red = Color::new(255, 0, 0, 255);
+        let mut tool = BrushTool::default();
+
+        let before = get_layer_data(&svc, id);
+        brush_stroke(&mut svc, &mut tool, id, 0, 0, red);
+        assert_ne!(before, get_layer_data(&svc, id));
+
+        svc.undo().unwrap();
+        assert_eq!(before, get_layer_data(&svc, id));
+    }
+
+    #[test]
+    fn t013_three_strokes_three_undos_each_reverts_one() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let r = Color::new(255, 0, 0, 255);
+        let g = Color::new(0, 255, 0, 255);
+        let b = Color::new(0, 0, 255, 255);
+        let mut tool = BrushTool::default();
+
+        brush_stroke(&mut svc, &mut tool, id, 0, 0, r);
+        brush_stroke(&mut svc, &mut tool, id, 1, 1, g);
+        brush_stroke(&mut svc, &mut tool, id, 2, 2, b);
+
+        // Undo third stroke
+        svc.undo().unwrap();
+        assert_eq!(get_pixel(&svc, id, 2, 2), Color::TRANSPARENT);
+        assert_eq!(get_pixel(&svc, id, 1, 1), g);
+        assert_eq!(get_pixel(&svc, id, 0, 0), r);
+
+        // Undo second stroke
+        svc.undo().unwrap();
+        assert_eq!(get_pixel(&svc, id, 1, 1), Color::TRANSPARENT);
+        assert_eq!(get_pixel(&svc, id, 0, 0), r);
+
+        // Undo first stroke
+        svc.undo().unwrap();
+        assert_eq!(get_pixel(&svc, id, 0, 0), Color::TRANSPARENT);
+    }
+
+    #[test]
+    fn t014_rapid_back_to_back_strokes_produce_separate_entries() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let mut tool = BrushTool::default();
+
+        // Simulate 4 rapid strokes (no delay — just sequential press/release)
+        for i in 0..4u32 {
+            brush_stroke(
+                &mut svc,
+                &mut tool,
+                id,
+                i % 4,
+                0,
+                Color::new(i as u8 * 50 + 50, 0, 0, 255),
+            );
+        }
+
+        // Each stroke should be independently undoable
+        for _ in 0..4 {
+            assert!(svc.can_undo());
+            svc.undo().unwrap();
+        }
+        assert!(!svc.can_undo());
+    }
+
+    // === Phase 4: T020-T023 — Mid-stroke undo ===
+
+    #[test]
+    fn t020_undo_during_active_stroke_with_pixels_cancels_stroke() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let red = Color::new(255, 0, 0, 255);
+        let mut tool = BrushTool::default();
+
+        // First complete stroke
+        brush_stroke(&mut svc, &mut tool, id, 0, 0, red);
+        let after_first = get_layer_data(&svc, id);
+
+        // Start second stroke (press + drag, no release)
+        svc.apply_tool_press(&mut tool, id, 1, 1, Color::WHITE, BrushSize::DEFAULT, 1.0)
+            .unwrap();
+        svc.apply_tool_drag(&mut tool, id, 2, 2, Color::WHITE, BrushSize::DEFAULT, 1.0)
+            .unwrap();
+        assert_ne!(after_first, get_layer_data(&svc, id));
+
+        // Undo mid-stroke: should finalize + undo the second stroke
+        svc.undo().unwrap();
+
+        // Canvas should show only the first stroke
+        assert_eq!(after_first, get_layer_data(&svc, id));
+    }
+
+    #[test]
+    fn t021_undo_during_active_stroke_no_pixels_undoes_previous() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let red = Color::new(255, 0, 0, 255);
+        let mut brush = BrushTool::default();
+
+        // First complete stroke
+        brush_stroke(&mut svc, &mut brush, id, 0, 0, red);
+
+        // Start a color picker "stroke" — ColorPickerTool does NOT modify pixels,
+        // so the pending snapshot will be discarded on undo
+        let mut picker = ColorPickerTool;
+        svc.apply_tool_press(
+            &mut picker,
+            id,
+            1,
+            1,
+            Color::TRANSPARENT,
+            BrushSize::DEFAULT,
+            1.0,
+        )
+        .unwrap();
+
+        // Undo mid-stroke with no modification: discard pending, undo previous
+        svc.undo().unwrap();
+
+        // First stroke should be undone (pending was discarded, normal undo ran)
+        assert_eq!(get_pixel(&svc, id, 0, 0), Color::TRANSPARENT);
+    }
+
+    #[test]
+    fn t022_redo_after_mid_stroke_undo_restores_cancelled_stroke() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let red = Color::new(255, 0, 0, 255);
+        let mut tool = BrushTool::default();
+
+        // First stroke
+        brush_stroke(&mut svc, &mut tool, id, 0, 0, red);
+
+        // Start second stroke with pixel modification
+        svc.apply_tool_press(&mut tool, id, 1, 1, Color::WHITE, BrushSize::DEFAULT, 1.0)
+            .unwrap();
+        svc.apply_tool_drag(&mut tool, id, 1, 1, Color::WHITE, BrushSize::DEFAULT, 1.0)
+            .unwrap();
+
+        // Mid-stroke undo (cancels the second stroke)
+        svc.undo().unwrap();
+        assert_eq!(get_pixel(&svc, id, 1, 1), Color::TRANSPARENT);
+
+        // Redo should restore the second stroke
+        svc.redo().unwrap();
+        assert_eq!(get_pixel(&svc, id, 1, 1), Color::WHITE);
+    }
+
+    #[test]
+    fn t023_subsequent_undo_redo_consistent_after_mid_stroke() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let mut tool = BrushTool::default();
+
+        // First stroke
+        brush_stroke(&mut svc, &mut tool, id, 0, 0, Color::WHITE);
+
+        // Second stroke with mid-stroke undo
+        svc.apply_tool_press(
+            &mut tool,
+            id,
+            1,
+            1,
+            Color::new(255, 0, 0, 255),
+            BrushSize::DEFAULT,
+            1.0,
+        )
+        .unwrap();
+        svc.apply_tool_drag(
+            &mut tool,
+            id,
+            1,
+            1,
+            Color::new(255, 0, 0, 255),
+            BrushSize::DEFAULT,
+            1.0,
+        )
+        .unwrap();
+        svc.undo().unwrap(); // Finalize + undo second stroke
+
+        // Undo first stroke
+        svc.undo().unwrap();
+        assert_eq!(get_pixel(&svc, id, 0, 0), Color::TRANSPARENT);
+
+        // Redo first stroke
+        svc.redo().unwrap();
+        assert_eq!(get_pixel(&svc, id, 0, 0), Color::WHITE);
+
+        // Redo second stroke
+        svc.redo().unwrap();
+        assert_eq!(get_pixel(&svc, id, 1, 1), Color::new(255, 0, 0, 255));
+    }
+
+    // === Phase 5: T026-T029 — Layer property and structural undo payloads ===
+
+    #[test]
+    fn t026_property_changes_produce_property_payload() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+
+        svc.set_layer_opacity(id, 0.5).unwrap();
+        assert!(matches!(
+            svc.undo_manager().peek_undo().unwrap().payload(),
+            UndoPayload::Property {
+                change: PropertyChange::Opacity(_),
+                ..
+            }
+        ));
+        svc.undo().unwrap();
+
+        svc.set_layer_blend_mode(id, BlendMode::Multiply).unwrap();
+        assert!(matches!(
+            svc.undo_manager().peek_undo().unwrap().payload(),
+            UndoPayload::Property {
+                change: PropertyChange::BlendMode(_),
+                ..
+            }
+        ));
+        svc.undo().unwrap();
+
+        svc.set_layer_visibility(id, false).unwrap();
+        assert!(matches!(
+            svc.undo_manager().peek_undo().unwrap().payload(),
+            UndoPayload::Property {
+                change: PropertyChange::Visibility(_),
+                ..
+            }
+        ));
+        svc.undo().unwrap();
+
+        svc.set_layer_name(id, "renamed").unwrap();
+        assert!(matches!(
+            svc.undo_manager().peek_undo().unwrap().payload(),
+            UndoPayload::Property {
+                change: PropertyChange::Name(_),
+                ..
+            }
+        ));
+        svc.undo().unwrap();
+
+        svc.set_layer_locked(id, true).unwrap();
+        assert!(matches!(
+            svc.undo_manager().peek_undo().unwrap().payload(),
+            UndoPayload::Property {
+                change: PropertyChange::Locked(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn t027_structural_ops_produce_full_stack_payload() {
+        let mut svc = test_service();
+
+        svc.add_layer(LayerId::new(2), "second").unwrap();
+        assert!(matches!(
+            svc.undo_manager().peek_undo().unwrap().payload(),
+            UndoPayload::FullStack(_)
+        ));
+        svc.undo().unwrap();
+
+        // Re-add for remove test
+        svc.add_layer(LayerId::new(2), "second").unwrap();
+        svc.remove_layer(LayerId::new(2)).unwrap();
+        assert!(matches!(
+            svc.undo_manager().peek_undo().unwrap().payload(),
+            UndoPayload::FullStack(_)
+        ));
+    }
+
+    #[test]
+    fn t028_undo_property_changes_reverts_values() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+
+        svc.set_layer_name(id, "renamed").unwrap();
+        svc.set_layer_opacity(id, 0.3).unwrap();
+
+        svc.undo().unwrap();
+        assert_eq!(
+            svc.texture().layer_stack().get_layer(id).unwrap().opacity(),
+            1.0
+        );
+
+        svc.undo().unwrap();
+        assert_eq!(
+            svc.texture().layer_stack().get_layer(id).unwrap().name(),
+            "base"
+        );
+    }
+
+    #[test]
+    fn t029_mixed_draw_and_layer_ops_undo_correct_order() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let mut tool = BrushTool::default();
+
+        brush_stroke(&mut svc, &mut tool, id, 0, 0, Color::WHITE);
+        svc.add_layer(LayerId::new(2), "second").unwrap();
+        svc.set_layer_opacity(id, 0.5).unwrap();
+
+        // Undo property change
+        svc.undo().unwrap();
+        assert_eq!(
+            svc.texture().layer_stack().get_layer(id).unwrap().opacity(),
+            1.0
+        );
+
+        // Undo add layer
+        svc.undo().unwrap();
+        assert_eq!(svc.texture().layer_stack().len(), 1);
+
+        // Undo draw
+        svc.undo().unwrap();
+        assert_eq!(get_pixel(&svc, id, 0, 0), Color::TRANSPARENT);
+    }
+
+    // === Phase 6: T033-T037 — Redo for all payload types ===
+
+    #[test]
+    fn t033_redo_single_layer_restores_pixels() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let red = Color::new(255, 0, 0, 255);
+        let mut tool = BrushTool::default();
+
+        brush_stroke(&mut svc, &mut tool, id, 0, 0, red);
+        let post_draw = get_layer_data(&svc, id);
+
+        svc.undo().unwrap();
+        assert_ne!(post_draw, get_layer_data(&svc, id));
+
+        svc.redo().unwrap();
+        assert_eq!(post_draw, get_layer_data(&svc, id));
+    }
+
+    #[test]
+    fn t034_redo_property_restores_value() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+
+        svc.set_layer_opacity(id, 0.3).unwrap();
+        svc.undo().unwrap();
+        assert_eq!(
+            svc.texture().layer_stack().get_layer(id).unwrap().opacity(),
+            1.0
+        );
+
+        svc.redo().unwrap();
+        assert_eq!(
+            svc.texture().layer_stack().get_layer(id).unwrap().opacity(),
+            0.3
+        );
+    }
+
+    #[test]
+    fn t035_redo_full_stack_restores_layer_stack() {
+        let mut svc = test_service();
+        svc.add_layer(LayerId::new(2), "second").unwrap();
+        assert_eq!(svc.texture().layer_stack().len(), 2);
+
+        svc.undo().unwrap();
+        assert_eq!(svc.texture().layer_stack().len(), 1);
+
+        svc.redo().unwrap();
+        assert_eq!(svc.texture().layer_stack().len(), 2);
+        assert!(svc
+            .texture()
+            .layer_stack()
+            .get_layer(LayerId::new(2))
+            .is_some());
+    }
+
+    #[test]
+    fn t036_new_action_after_undo_clears_redo_entirely() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let mut tool = BrushTool::default();
+
+        brush_stroke(&mut svc, &mut tool, id, 0, 0, Color::WHITE);
+        svc.set_layer_opacity(id, 0.5).unwrap();
+
+        svc.undo().unwrap();
+        svc.undo().unwrap();
+        assert!(svc.can_redo());
+
+        // New action clears redo
+        brush_stroke(&mut svc, &mut tool, id, 1, 1, Color::BLACK);
+        assert!(!svc.can_redo());
+    }
+
+    #[test]
+    fn t037_redo_on_empty_returns_error() {
+        let mut svc = test_service();
+        assert_eq!(svc.redo().unwrap_err(), DomainError::EmptyHistory);
+    }
+
+    #[test]
+    fn t038a_redo_move_layer_restores_order() {
+        let mut svc = test_service();
+        svc.add_layer(LayerId::new(2), "second").unwrap();
+        svc.add_layer(LayerId::new(3), "third").unwrap();
+
+        svc.move_layer(0, 2).unwrap();
+        assert_eq!(svc.texture().layer_stack().layers()[2].name(), "base");
+
+        svc.undo().unwrap();
+        assert_eq!(svc.texture().layer_stack().layers()[0].name(), "base");
+
+        svc.redo().unwrap();
+        assert_eq!(svc.texture().layer_stack().layers()[2].name(), "base");
+    }
+
+    #[test]
+    fn t038b_redo_property_all_variants() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+
+        // Name
+        svc.set_layer_name(id, "renamed").unwrap();
+        svc.undo().unwrap();
+        assert_eq!(
+            svc.texture().layer_stack().get_layer(id).unwrap().name(),
+            "base"
+        );
+        svc.redo().unwrap();
+        assert_eq!(
+            svc.texture().layer_stack().get_layer(id).unwrap().name(),
+            "renamed"
+        );
+        svc.undo().unwrap();
+
+        // BlendMode
+        svc.set_layer_blend_mode(id, BlendMode::Multiply).unwrap();
+        svc.undo().unwrap();
+        assert_eq!(
+            svc.texture()
+                .layer_stack()
+                .get_layer(id)
+                .unwrap()
+                .blend_mode(),
+            BlendMode::Normal
+        );
+        svc.redo().unwrap();
+        assert_eq!(
+            svc.texture()
+                .layer_stack()
+                .get_layer(id)
+                .unwrap()
+                .blend_mode(),
+            BlendMode::Multiply
+        );
+        svc.undo().unwrap();
+
+        // Visibility
+        svc.set_layer_visibility(id, false).unwrap();
+        svc.undo().unwrap();
+        assert!(svc
+            .texture()
+            .layer_stack()
+            .get_layer(id)
+            .unwrap()
+            .is_visible());
+        svc.redo().unwrap();
+        assert!(!svc
+            .texture()
+            .layer_stack()
+            .get_layer(id)
+            .unwrap()
+            .is_visible());
+        svc.undo().unwrap();
+
+        // Locked
+        svc.set_layer_locked(id, true).unwrap();
+        svc.undo().unwrap();
+        assert!(!svc
+            .texture()
+            .layer_stack()
+            .get_layer(id)
+            .unwrap()
+            .is_locked());
+        svc.redo().unwrap();
+        assert!(svc
+            .texture()
+            .layer_stack()
+            .get_layer(id)
+            .unwrap()
+            .is_locked());
+    }
+
+    // === Phase 7: T039-T041 — Memory efficiency validation ===
+
+    #[test]
+    fn t039_draw_on_5_layer_texture_produces_single_layer_entry() {
+        let mut tex = Texture::new("ns".into(), "p".into(), 4, 4).unwrap();
+        for i in 1..=5u128 {
+            tex.add_layer(LayerId::new(i), format!("layer_{}", i))
+                .unwrap();
+        }
+        let mut svc = EditorService::new(tex);
+        let mut tool = BrushTool::default();
+
+        brush_stroke(&mut svc, &mut tool, LayerId::new(3), 0, 0, Color::WHITE);
+
+        let entry = svc.undo_manager().peek_undo().unwrap();
+        match entry.payload() {
+            UndoPayload::SingleLayer(snap) => {
+                assert_eq!(snap.id, LayerId::new(3));
+            }
+            other => panic!("expected SingleLayer, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn t040_property_change_contains_no_pixel_data() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+
+        svc.set_layer_opacity(id, 0.5).unwrap();
+
+        let entry = svc.undo_manager().peek_undo().unwrap();
+        assert!(
+            matches!(entry.payload(), UndoPayload::Property { .. }),
+            "property change must use Property payload, not FullStack"
+        );
+    }
+
+    #[test]
+    fn t041_50_draws_on_5_layer_texture_all_single_layer() {
+        let mut tex = Texture::new("ns".into(), "p".into(), 4, 4).unwrap();
+        for i in 1..=5u128 {
+            tex.add_layer(LayerId::new(i), format!("layer_{}", i))
+                .unwrap();
+        }
+        let mut svc = EditorService::new(tex);
+        let mut tool = BrushTool::default();
+
+        for i in 0..50u32 {
+            brush_stroke(
+                &mut svc,
+                &mut tool,
+                LayerId::new(((i as u128) % 5) + 1),
+                i % 4,
+                (i / 4) % 4,
+                Color::new(i as u8, 0, 0, 255),
+            );
+        }
+
+        // Verify all 50 entries are SingleLayer (not FullStack)
+        let mut count = 0;
+        while svc.can_undo() {
+            let entry = svc.undo_manager().peek_undo().unwrap();
+            assert!(
+                matches!(entry.payload(), UndoPayload::SingleLayer(_)),
+                "draw entry {} should be SingleLayer",
+                count
+            );
+            svc.undo().unwrap();
+            count += 1;
+        }
+        assert!(count > 0);
+    }
+
+    // === Phase 8: T043-T047 — Edge cases ===
+
+    #[test]
+    fn t043_max_capacity_with_mixed_payloads() {
+        let mut tex = test_texture();
+        tex.add_layer(LayerId::new(1), "base".to_string()).unwrap();
+        let mut svc = EditorService::with_max_history(tex, 3);
+        let id = LayerId::new(1);
+        let mut tool = BrushTool::default();
+
+        // Push 4 entries into a max_depth=3 manager: oldest evicted
+        brush_stroke(&mut svc, &mut tool, id, 0, 0, Color::WHITE);
+        svc.set_layer_opacity(id, 0.5).unwrap();
+        brush_stroke(&mut svc, &mut tool, id, 1, 1, Color::new(255, 0, 0, 255));
+        svc.set_layer_name(id, "renamed").unwrap();
+
+        // Only 3 should remain
+        let mut count = 0;
+        while svc.can_undo() {
+            svc.undo().unwrap();
+            count += 1;
+        }
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn t044_delete_layer_with_painted_content_single_fullstack_undo() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let mut tool = BrushTool::default();
+        let red = Color::new(255, 0, 0, 255);
+
+        brush_stroke(&mut svc, &mut tool, id, 0, 0, red);
+
+        // Delete the layer (includes painted content)
+        svc.remove_layer(id).unwrap();
+        assert!(svc.texture().layer_stack().is_empty());
+
+        // Undo should restore the layer AND its content
+        svc.undo().unwrap();
+        assert_eq!(svc.texture().layer_stack().len(), 1);
+        assert_eq!(get_pixel(&svc, id, 0, 0), red);
+    }
+
+    #[test]
+    fn t045_undo_layer_deletion_then_draw_creates_single_layer_entries() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let red = Color::new(255, 0, 0, 255);
+        let mut tool = BrushTool::default();
+
+        brush_stroke(&mut svc, &mut tool, id, 0, 0, red);
+
+        // Delete and undo
+        svc.remove_layer(id).unwrap();
+        svc.undo().unwrap();
+
+        // Draw on the restored layer
+        brush_stroke(&mut svc, &mut tool, id, 1, 1, Color::WHITE);
+
+        // The new draw should produce SingleLayer
+        let entry = svc.undo_manager().peek_undo().unwrap();
+        assert!(matches!(entry.payload(), UndoPayload::SingleLayer(_)));
+    }
+
+    #[test]
+    fn t046_undo_only_layer_creation_follows_minimum_layer_policy() {
+        // The initial layer is created by the factory (new_blank / from_pixel_buffer),
+        // which does NOT push an undo entry. Therefore, undoing back to "before the
+        // only layer existed" is impossible — EmptyHistory is returned.
+        let mut svc = test_service();
+        assert_eq!(svc.texture().layer_stack().len(), 1);
+        assert!(!svc.can_undo());
+        assert_eq!(svc.undo().unwrap_err(), DomainError::EmptyHistory);
+        // Layer is still there
+        assert_eq!(svc.texture().layer_stack().len(), 1);
+    }
+
+    #[test]
+    fn t047_rapid_undo_redo_alternation_stays_consistent() {
+        let mut svc = test_service();
+        let id = LayerId::new(1);
+        let mut tool = BrushTool::default();
+
+        // Create 5 draw entries
+        for i in 0..5u32 {
+            brush_stroke(
+                &mut svc,
+                &mut tool,
+                id,
+                i % 4,
+                0,
+                Color::new(i as u8 * 50 + 50, 0, 0, 255),
+            );
+        }
+
+        // Rapid undo/redo alternation 100 times
+        for _ in 0..100 {
+            if svc.can_undo() {
+                svc.undo().unwrap();
+            }
+            if svc.can_redo() {
+                svc.redo().unwrap();
+            }
+        }
+
+        // System should still be in a consistent state
+        while svc.can_undo() {
+            svc.undo().unwrap();
+        }
+        // All pixels should be transparent (initial state)
+        for x in 0..4 {
+            assert_eq!(get_pixel(&svc, id, x, 0), Color::TRANSPARENT);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Each paint stroke now produces exactly one independently undoable entry, including rapid back-to-back strokes
- Mid-stroke Ctrl+Z cleanly finalizes the in-progress stroke then undoes it (redoable via Ctrl+Y)
- Layer operations (add, remove, reorder, rename, visibility, blend mode, opacity, locked) are each individually undoable
- Undo entries capture only the data actually changed — SingleLayer for draws, Property metadata for layer settings, FullStack only for structural ops

## Motivation

Closes #35

## What changed

```
src-tauri/src/
├── domain/
│   ├── undo.rs               # + PropertyKind enum, PropertyChange enum, UndoPayload enum,
│   │                         #   UndoEntry uses UndoPayload, UndoEntry::new pub(crate)
│   └── layer_stack.rs        # + restore_single_layer(LayerSnapshot) method
├── use_cases/
│   └── editor_service.rs     # pending_snapshot → pending_layer_snapshot (Option<LayerSnapshot>)
│                             # apply_history_swap matches on 3 payload variants
│                             # undo() returns Result<bool> (was_mid_stroke flag)
│                             # Mid-stroke finalization built into undo()
│                             # All property setters capture PropertyChange old value
└── commands/
    └── history_commands.rs   # Tool cancel on mid-stroke via the returned was_mid_stroke flag

specs/035-fix-undo-redo/      # Full speckit artifacts (spec, plan, research, tasks, etc.)
```

## Key decisions

| Decision | Why |
|----------|-----|
| Discriminated `UndoPayload` (SingleLayer / FullStack / Property) instead of uniform `TextureSnapshot` | Memory proportional to changes — 5-layer 64×64 history goes from ~40 MB to ~6 MB |
| `pending_layer_snapshot` captures only the target layer at press time | Eliminates the full-stack clone on every press; single source of truth for both release and mid-stroke undo |
| `undo()` returns `Result<bool>` (was_mid_stroke) | Keeps tool-cancel coordination in the command layer without leaking business logic — use case stays authoritative |
| `PropertyKind` enum separate from `PropertyChange` | Avoids conflating discriminant and value in `read_property`; makes call sites self-documenting |
| Keep `FullStack` for structural ops (add/remove/reorder) | Constitution Principle VI (Simplicity) — these are rare, and inverse-command logic adds complexity for marginal gains |
| `UndoEntry::new` is `pub(crate)` | Prevents external construction of invalid operation/payload combinations |

## Out of scope

- Frontend changes: no IPC signature changes, existing error handling covers the mid-stroke edge case
- Structural ops (add/remove/reorder) still use FullStack snapshots — deliberate per research R1
- Command registry integration (#34) — already landed, undo/redo commands reuse the shared dispatch

## Verification

- `cargo test` — **293 tests, 0 failures** (26 new tests for undo/redo, including t020-t047 covering mid-stroke, memory efficiency, edge cases)
- `/speckit.verify.run` — PASS (11/11 FR covered, 6/6 user stories, constitution compliant)
- `/speckit.review.run` — all 3 Important, 4 Medium and 6 Suggestion findings from the review were addressed
- `cargo fmt` — clean
- Pre-commit hook (husky + lint-staged) — passing

## How to test

```bash
cd src-tauri
cargo test            # run all tests (293 should pass)
cargo test t0         # run only the new phase tests (t011-t047)
cargo test undo       # run all undo-related tests
```

Manual acceptance scenarios from `specs/035-fix-undo-redo/quickstart.md`:

1. Draw 3 strokes, Ctrl+Z ×3 → each stroke reverts individually
2. Draw 4 strokes in rapid succession (< 500ms), Ctrl+Z ×4 → each removed independently
3. Start a stroke, keep mouse down, press Ctrl+Z → stroke is cancelled, Ctrl+Y restores it
4. Add layer → rename → change blend mode → Ctrl+Z ×3 → each reverts one operation